### PR TITLE
docs: add env example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!**/.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ A modern web application built with the latest technologies including Next.js 15
    ```
 
 3. **Environment Setup:**
-   Create `.env.local` file with your database and authentication credentials:
+   Copy `.env.example` to `.env.local` and update the values:
+   ```bash
+   cp .env.example .env.local
+   ```
+   Then edit `.env.local` with your database and authentication credentials:
    ```env
    # Database
    DATABASE_URL="your-neon-database-url"

--- a/main/.env.example
+++ b/main/.env.example
@@ -1,0 +1,11 @@
+# Database
+DATABASE_URL="your-neon-database-url"
+
+# Clerk Authentication
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="your-clerk-publishable-key"
+CLERK_SECRET_KEY="your-clerk-secret-key"
+CLERK_WEBHOOK_SECRET="your-webhook-secret"
+
+# Next.js
+NEXTAUTH_SECRET="your-secret-key"
+NEXTAUTH_URL="http://localhost:3000"

--- a/main/.gitignore
+++ b/main/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!**/.env.example
 
 # vercel
 .vercel

--- a/main/README.md
+++ b/main/README.md
@@ -35,7 +35,11 @@ A modern web application built with the latest technologies including Next.js 15
    ```
 
 3. **Environment Setup:**
-   Create `.env.local` file with your database and authentication credentials:
+   Copy `.env.example` to `.env.local` and update the values:
+   ```bash
+   cp .env.example .env.local
+   ```
+   Then edit `.env.local` with your database and authentication credentials:
    ```env
    # Database
    DATABASE_URL="your-neon-database-url"


### PR DESCRIPTION
## Summary
- add an example environment file
- reference `.env.example` in setup docs
- allow `.env.example` through gitignore

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863046bf55c832796d1d33c24530490