### PR TITLE
feat: add IFTA trip tracking

### DIFF
--- a/Features.md
+++ b/Features.md
@@ -547,6 +547,8 @@ Automate mileage and fuel tracking for IFTA (International Fuel Tax Agreement) r
 2. Enter trip data and fuel purchase information as required:
 
     - Record trips with distance traveled in each state/province.
+      Mileage is automatically calculated from start and end coordinates and
+      trips are flagged as interstate when crossing state lines.
     - Log fuel purchases with quantity and location (state/province).
 
 3. After inputting data for the period, use the module’s report function to **Generate IFTA Report**

--- a/main/src/app/dashboard/ifta/trips/page.tsx
+++ b/main/src/app/dashboard/ifta/trips/page.tsx
@@ -1,0 +1,84 @@
+import { requirePermission } from '@/lib/rbac'
+import { getTripsByOrg } from '@/lib/fetchers/ifta'
+import { recordTripAction } from '@/lib/actions/ifta'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+
+export default async function TripsPage() {
+  const user = await requirePermission('org:driver:record_trip')
+  const trips = await getTripsByOrg(user.orgId)
+
+  return (
+    <div className="min-h-screen p-8">
+      <div className="max-w-3xl mx-auto space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Record Trip</CardTitle>
+            <CardDescription>Manual trip entry</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form action={recordTripAction} className="space-y-4">
+              <input type="hidden" name="driverId" value={user.id} />
+              <div className="space-y-2">
+                <label htmlFor="loadId" className="text-sm font-medium">Load ID</label>
+                <Input id="loadId" name="loadId" type="number" />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="startLat" className="text-sm font-medium">Start Latitude</label>
+                <Input id="startLat" name="startLat" type="number" step="any" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="startLng" className="text-sm font-medium">Start Longitude</label>
+                <Input id="startLng" name="startLng" type="number" step="any" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="startState" className="text-sm font-medium">Start State</label>
+                <Input id="startState" name="startState" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="endLat" className="text-sm font-medium">End Latitude</label>
+                <Input id="endLat" name="endLat" type="number" step="any" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="endLng" className="text-sm font-medium">End Longitude</label>
+                <Input id="endLng" name="endLng" type="number" step="any" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="endState" className="text-sm font-medium">End State</label>
+                <Input id="endState" name="endState" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="startedAt" className="text-sm font-medium">Start Time</label>
+                <Input id="startedAt" name="startedAt" type="datetime-local" required />
+              </div>
+              <div className="space-y-2">
+                <label htmlFor="endedAt" className="text-sm font-medium">End Time</label>
+                <Input id="endedAt" name="endedAt" type="datetime-local" required />
+              </div>
+              <Button type="submit">Record Trip</Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Trips</CardTitle>
+            <CardDescription>Recent entries</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            {trips.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No trips recorded</p>
+            ) : (
+              trips.map(trip => (
+                <div key={trip.id} className="text-sm">
+                  Trip #{trip.id} - {trip.distance ?? 0} miles ({trip.isInterstate ? 'Interstate' : 'Intrastate'})
+                </div>
+              ))
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/main/src/lib/actions/ifta.ts
+++ b/main/src/lib/actions/ifta.ts
@@ -1,0 +1,82 @@
+'use server'
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { trips } from '@/lib/schema'
+import { requirePermission } from '@/lib/rbac'
+import { createAuditLog, AUDIT_ACTIONS, AUDIT_RESOURCES } from '@/lib/audit'
+import { revalidatePath } from 'next/cache'
+
+const TripFormSchema = z.object({
+  driverId: z.coerce.number().optional(),
+  loadId: z.coerce.number().optional(),
+  startLat: z.coerce.number(),
+  startLng: z.coerce.number(),
+  startState: z.string().min(2),
+  endLat: z.coerce.number(),
+  endLng: z.coerce.number(),
+  endState: z.string().min(2),
+  startedAt: z.coerce.date(),
+  endedAt: z.coerce.date()
+})
+
+function haversine(lat1: number, lon1: number, lat2: number, lon2: number) {
+  const R = 3958.8 // miles
+  const rad = Math.PI / 180
+  const dLat = (lat2 - lat1) * rad
+  const dLon = (lon2 - lon1) * rad
+  const a = Math.sin(dLat / 2) ** 2 +
+            Math.cos(lat1 * rad) * Math.cos(lat2 * rad) *
+            Math.sin(dLon / 2) ** 2
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  return R * c
+}
+
+export async function recordTripAction(formData: FormData) {
+  const parseResult = TripFormSchema.safeParse({
+    driverId: formData.get('driverId'),
+    loadId: formData.get('loadId'),
+    startLat: formData.get('startLat'),
+    startLng: formData.get('startLng'),
+    startState: formData.get('startState'),
+    endLat: formData.get('endLat'),
+    endLng: formData.get('endLng'),
+    endState: formData.get('endState'),
+    startedAt: formData.get('startedAt'),
+    endedAt: formData.get('endedAt')
+  })
+
+  if (!parseResult.success) {
+    return { success: false, error: 'Invalid input', issues: parseResult.error.flatten() }
+  }
+
+  const currentUser = await requirePermission('org:driver:record_trip')
+  const data = parseResult.data
+
+  const distance = haversine(data.startLat, data.startLng, data.endLat, data.endLng)
+  const isInterstate = data.startState !== data.endState
+
+  const [trip] = await db.insert(trips).values({
+    orgId: currentUser.orgId,
+    driverId: data.driverId || parseInt(currentUser.id),
+    loadId: data.loadId,
+    startLocation: { lat: data.startLat, lng: data.startLng, state: data.startState },
+    endLocation: { lat: data.endLat, lng: data.endLng, state: data.endState },
+    distance,
+    jurisdictions: [ { state: data.startState, miles: distance } ],
+    isInterstate,
+    startedAt: data.startedAt,
+    endedAt: data.endedAt,
+    createdById: parseInt(currentUser.id)
+  }).returning()
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.TRIP_CREATE,
+    resource: AUDIT_RESOURCES.TRIP,
+    resourceId: trip.id.toString(),
+    details: { distance, isInterstate }
+  })
+
+  revalidatePath('/dashboard/ifta/trips')
+  return { success: true }
+}

--- a/main/src/lib/audit.ts
+++ b/main/src/lib/audit.ts
@@ -108,6 +108,9 @@ export const AUDIT_ACTIONS = {
   VEHICLE_CREATE: 'vehicle.create',
   VEHICLE_UPDATE: 'vehicle.update',
   VEHICLE_ASSIGN: 'vehicle.assign',
+
+  // Trip actions
+  TRIP_CREATE: 'trip.create',
   
   // Document actions
   DOCUMENT_UPLOAD: 'document.upload',
@@ -134,4 +137,5 @@ export const AUDIT_RESOURCES = {
   DOCUMENT: 'document',
   ORGANIZATION: 'organization',
   COMPLIANCE: 'compliance',
+  TRIP: 'trip',
 } as const;

--- a/main/src/lib/fetchers/ifta.ts
+++ b/main/src/lib/fetchers/ifta.ts
@@ -1,0 +1,7 @@
+import { db } from '@/lib/db'
+import { trips } from '@/lib/schema'
+import { eq } from 'drizzle-orm'
+
+export async function getTripsByOrg(orgId: number) {
+  return await db.select().from(trips).where(eq(trips.orgId, orgId))
+}

--- a/main/src/lib/schema.ts
+++ b/main/src/lib/schema.ts
@@ -115,6 +115,25 @@ export const documents = pgTable('documents', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 
+// Trips table
+export const trips = pgTable('trips', {
+  id: serial('id').primaryKey(),
+  orgId: serial('org_id').references(() => organizations.id).notNull(),
+  driverId: serial('driver_id').references(() => drivers.id),
+  vehicleId: serial('vehicle_id').references(() => vehicles.id),
+  loadId: serial('load_id').references(() => loads.id),
+  startLocation: jsonb('start_location').notNull(), // { lat, lng, state }
+  endLocation: jsonb('end_location').notNull(), // { lat, lng, state }
+  distance: serial('distance'), // in miles
+  jurisdictions: jsonb('jurisdictions').default('[]'), // [{state, miles}]
+  isInterstate: boolean('is_interstate').default(false),
+  startedAt: timestamp('started_at').notNull(),
+  endedAt: timestamp('ended_at').notNull(),
+  createdById: serial('created_by_id').references(() => users.id).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+  updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
 // Relations
 export const organizationsRelations = relations(organizations, ({ many }) => ({
   users: many(users),
@@ -122,6 +141,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   loads: many(loads),
   auditLogs: many(auditLogs),
   documents: many(documents),
+  trips: many(trips),
 }));
 
 export const usersRelations = relations(users, ({ one, many }) => ({
@@ -143,6 +163,7 @@ export const driversRelations = relations(drivers, ({ one, many }) => ({
   currentVehicle: one(vehicles),
   assignedLoads: many(loads),
   documents: many(documents),
+  trips: many(trips),
 }));
 
 export const vehiclesRelations = relations(vehicles, ({ one, many }) => ({
@@ -155,6 +176,7 @@ export const vehiclesRelations = relations(vehicles, ({ one, many }) => ({
     references: [drivers.id],
   }),
   assignedLoads: many(loads),
+  trips: many(trips),
 }));
 
 export const loadsRelations = relations(loads, ({ one, many }) => ({
@@ -175,6 +197,7 @@ export const loadsRelations = relations(loads, ({ one, many }) => ({
     references: [users.id],
   }),
   documents: many(documents),
+  trips: many(trips),
 }));
 
 export const documentsRelations = relations(documents, ({ one }) => ({
@@ -200,6 +223,29 @@ export const documentsRelations = relations(documents, ({ one }) => ({
   }),
 }));
 
+export const tripsRelations = relations(trips, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [trips.orgId],
+    references: [organizations.id],
+  }),
+  driver: one(drivers, {
+    fields: [trips.driverId],
+    references: [drivers.id],
+  }),
+  vehicle: one(vehicles, {
+    fields: [trips.vehicleId],
+    references: [vehicles.id],
+  }),
+  load: one(loads, {
+    fields: [trips.loadId],
+    references: [loads.id],
+  }),
+  createdBy: one(users, {
+    fields: [trips.createdById],
+    references: [users.id],
+  })
+}));
+
 // Export types
 export type Organization = typeof organizations.$inferSelect;
 export type NewOrganization = typeof organizations.$inferInsert;
@@ -215,3 +261,5 @@ export type AuditLog = typeof auditLogs.$inferSelect;
 export type NewAuditLog = typeof auditLogs.$inferInsert;
 export type Document = typeof documents.$inferSelect;
 export type NewDocument = typeof documents.$inferInsert;
+export type Trip = typeof trips.$inferSelect;
+export type NewTrip = typeof trips.$inferInsert;

--- a/main/src/types/rbac.ts
+++ b/main/src/types/rbac.ts
@@ -53,6 +53,7 @@ export const ROLE_PERMISSIONS: Record<SystemRoles, string[]> = {
     'org:driver:update_load_status',
     'org:driver:upload_documents',
     'org:driver:log_hos',
+    'org:driver:record_trip',
     'org:compliance:upload_review_compliance',
     'org:compliance:generate_compliance_req',
     'org:compliance:access_audit_logs'
@@ -63,14 +64,16 @@ export const ROLE_PERMISSIONS: Record<SystemRoles, string[]> = {
     'org:dispatcher:assign_drivers',
     'org:dispatcher:create_edit_loads',
     'org:driver:view_assigned_loads',
-    'org:driver:update_load_status'
+    'org:driver:update_load_status',
+    'org:driver:record_trip'
   ],
   [SystemRoles.DRIVER]: [
     'org:sys_profile:manage',
     'org:driver:view_assigned_loads',
     'org:driver:update_load_status',
     'org:driver:upload_documents',
-    'org:driver:log_hos'
+    'org:driver:log_hos',
+    'org:driver:record_trip'
   ],
   [SystemRoles.COMPLIANCE]: [
     'org:sys_profile:manage',


### PR DESCRIPTION
Closes #57

## Summary
- create trips table and relations
- add recordTripAction server action
- expose getTripsByOrg fetcher
- allow drivers to record trips via new dashboard page
- document automatic mileage calculation
- extend audit actions/resources and RBAC permissions

## Checklist
- [x] Passes `npm run lint`
- [ ] Passes `npm run typecheck`
- [ ] Passes `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6863042d41488327b0cd09eb8afc41e4