### PR TITLE
chore: add typecheck script

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ npm run dev          # Start development server with Turbopack
 npm run build        # Build for production
 npm run start        # Start production server
 npm run lint         # Run ESLint
+npm run typecheck    # Run TypeScript type check
 
 # Database
 npm run db:generate  # Generate migration files

--- a/main/README.md
+++ b/main/README.md
@@ -176,6 +176,7 @@ npm run dev          # Start development server with Turbopack
 npm run build        # Build for production
 npm run start        # Start production server
 npm run lint         # Run ESLint
+npm run typecheck    # Run TypeScript type check
 
 # Database
 npm run db:generate  # Generate migration files

--- a/main/package.json
+++ b/main/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",


### PR DESCRIPTION
## Summary
- add `typecheck` npm script
- document `npm run typecheck` in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run test` *(fails: Missing script)*
- `npm run test:all` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863046730d08327aae5b8607683285c