### PR TITLE
feat: add driver profile management

### DIFF
--- a/main/src/app/drivers/[id]/edit/page.tsx
+++ b/main/src/app/drivers/[id]/edit/page.tsx
@@ -1,0 +1,25 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getDriverById } from '@/lib/fetchers/drivers'
+import DriverForm from '@/features/drivers/components/DriverForm'
+import { Button } from '@/components/ui/button'
+
+interface Params { params: { id: string } }
+
+export default async function EditDriverPage({ params }: Params) {
+  const id = Number(params.id)
+  const driver = await getDriverById(id)
+  if (!driver) return notFound()
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Edit Driver</h1>
+        <Link href={`/drivers/${id}`}>
+          <Button variant="outline">Cancel</Button>
+        </Link>
+      </div>
+      <DriverForm driver={driver} />
+    </div>
+  )
+}

--- a/main/src/app/drivers/[id]/page.tsx
+++ b/main/src/app/drivers/[id]/page.tsx
@@ -1,0 +1,30 @@
+import { notFound } from 'next/navigation'
+import Link from 'next/link'
+import { getDriverById } from '@/lib/fetchers/drivers'
+import DriverSummary from '@/features/drivers/components/DriverSummary'
+import { Button } from '@/components/ui/button'
+
+interface Params { params: { id: string } }
+
+export default async function DriverDetailPage({ params }: Params) {
+  const id = Number(params.id)
+  const driver = await getDriverById(id)
+  if (!driver) return notFound()
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Driver Profile</h1>
+        <div className="flex gap-2">
+          <Link href={`/drivers/${id}/edit`}>
+            <Button variant="outline">Edit</Button>
+          </Link>
+          <Link href="/drivers">
+            <Button variant="outline">Back</Button>
+          </Link>
+        </div>
+      </div>
+      <DriverSummary driver={driver} />
+    </div>
+  )
+}

--- a/main/src/app/drivers/new/page.tsx
+++ b/main/src/app/drivers/new/page.tsx
@@ -1,0 +1,17 @@
+import DriverForm from '@/features/drivers/components/DriverForm'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+
+export default function NewDriverPage() {
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Register Driver</h1>
+        <Link href="/drivers">
+          <Button variant="outline">Back to list</Button>
+        </Link>
+      </div>
+      <DriverForm />
+    </div>
+  )
+}

--- a/main/src/app/drivers/page.tsx
+++ b/main/src/app/drivers/page.tsx
@@ -1,0 +1,29 @@
+import Link from 'next/link'
+import { getAllDrivers } from '@/lib/fetchers/drivers'
+import DriverSummary from '@/features/drivers/components/DriverSummary'
+import { Button } from '@/components/ui/button'
+
+export const dynamic = 'force-dynamic'
+
+export default async function DriversPage() {
+  const drivers = await getAllDrivers()
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Drivers</h1>
+        <Link href="/drivers/new">
+          <Button>Create Driver</Button>
+        </Link>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        {drivers.map(driver => (
+          <Link key={driver.id} href={`/drivers/${driver.id}`}
+            className="hover:opacity-80 transition-opacity">
+            <DriverSummary driver={driver} />
+          </Link>
+        ))}
+        {drivers.length === 0 && <p>No drivers found.</p>}
+      </div>
+    </div>
+  )
+}

--- a/main/src/features/drivers/components/DriverForm.tsx
+++ b/main/src/features/drivers/components/DriverForm.tsx
@@ -1,0 +1,58 @@
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+import { createDriver, updateDriver } from '@/lib/actions/drivers'
+import { DriverProfile } from '@/types/drivers'
+
+interface DriverFormProps {
+  driver?: DriverProfile
+}
+
+export default function DriverForm({ driver }: DriverFormProps) {
+  const action = driver ? updateDriver : createDriver
+
+  return (
+    <form action={action} className="space-y-4 max-w-md">
+      {driver && <input type="hidden" name="id" value={driver.id} />}
+      <div className="space-y-2">
+        <Label htmlFor="name">Name</Label>
+        <Input id="name" name="name" defaultValue={driver?.name ?? ''} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input
+          id="email"
+          name="email"
+          type="email"
+          defaultValue={driver?.email ?? ''}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="licenseNumber">License Number</Label>
+        <Input
+          id="licenseNumber"
+          name="licenseNumber"
+          defaultValue={driver?.licenseNumber ?? ''}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="licenseExpiry">License Expiry</Label>
+        <Input
+          id="licenseExpiry"
+          name="licenseExpiry"
+          type="date"
+          defaultValue={driver?.licenseExpiry ? driver.licenseExpiry.toISOString().slice(0, 10) : ''}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="dotNumber">DOT Number</Label>
+        <Input id="dotNumber" name="dotNumber" defaultValue={driver?.dotNumber ?? ''} />
+      </div>
+      <Button type="submit" className="mt-4">
+        {driver ? 'Update Driver' : 'Create Driver'}
+      </Button>
+    </form>
+  )
+}

--- a/main/src/features/drivers/components/DriverSummary.tsx
+++ b/main/src/features/drivers/components/DriverSummary.tsx
@@ -1,0 +1,19 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { DriverProfile } from '@/types/drivers'
+
+export default function DriverSummary({ driver }: { driver: DriverProfile }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{driver.name || 'Unnamed Driver'}</CardTitle>
+        <CardDescription>{driver.email}</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        <p><strong>License:</strong> {driver.licenseNumber || 'N/A'}</p>
+        <p><strong>License Expiry:</strong> {driver.licenseExpiry ? driver.licenseExpiry.toLocaleDateString() : 'N/A'}</p>
+        {driver.dotNumber && <p><strong>DOT:</strong> {driver.dotNumber}</p>}
+        <p><strong>Status:</strong> {driver.isAvailable ? 'Available' : 'Unavailable'}</p>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/lib/fetchers/drivers.ts
+++ b/main/src/lib/fetchers/drivers.ts
@@ -1,0 +1,45 @@
+import { db } from '@/lib/db';
+import { drivers, users } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import { DriverProfile } from '@/types/drivers';
+
+export async function getAllDrivers(): Promise<DriverProfile[]> {
+  const rows = await db
+    .select({
+      id: drivers.id,
+      userId: drivers.userId,
+      name: users.name,
+      email: users.email,
+      licenseNumber: drivers.licenseNumber,
+      licenseExpiry: drivers.licenseExpiry,
+      dotNumber: drivers.dotNumber,
+      isAvailable: drivers.isAvailable,
+      createdAt: drivers.createdAt,
+      updatedAt: drivers.updatedAt,
+    })
+    .from(drivers)
+    .innerJoin(users, eq(drivers.userId, users.id));
+
+  return rows;
+}
+
+export async function getDriverById(id: number): Promise<DriverProfile | undefined> {
+  const [row] = await db
+    .select({
+      id: drivers.id,
+      userId: drivers.userId,
+      name: users.name,
+      email: users.email,
+      licenseNumber: drivers.licenseNumber,
+      licenseExpiry: drivers.licenseExpiry,
+      dotNumber: drivers.dotNumber,
+      isAvailable: drivers.isAvailable,
+      createdAt: drivers.createdAt,
+      updatedAt: drivers.updatedAt,
+    })
+    .from(drivers)
+    .innerJoin(users, eq(drivers.userId, users.id))
+    .where(eq(drivers.id, id));
+
+  return row;
+}

--- a/main/src/types/drivers.ts
+++ b/main/src/types/drivers.ts
@@ -1,0 +1,12 @@
+export interface DriverProfile {
+  id: number;
+  userId: number;
+  name: string | null;
+  email: string;
+  licenseNumber: string | null;
+  licenseExpiry: Date | null;
+  dotNumber: string | null;
+  isAvailable: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -7,7 +7,7 @@ This page summarizes the main features and user flows in Road.io.
 1. **Sign Up & Onboard:** Register and onboard your company.
 2. **Invite Team Members:** Send email invites to users.
 3. **Add Vehicles:** Populate fleet data.
-4. **Add Drivers:** Add driver profiles.
+4. **Add Drivers:** Register driver profiles and manage licensing.
 5. **Create Loads:** Schedule deliveries.
 6. **Track Operations:** Use dashboards and modules.
 7. **Explore Modules:** See [Module Guides](#module-guides).


### PR DESCRIPTION
Closes #49

## Summary
- implement driver fetchers and actions with validation
- add DriverForm and DriverSummary components
- create drivers pages for list, detail, create, and edit
- document driver profile management in Features guide

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: Missing script)*
- `npm run test` *(fails: Missing script)*
- `npm run test:all` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863041a96d883278a2c50a48bb272d5