### PR TITLE
feat: add load management and document uploads

### DIFF
--- a/main/src/app/dashboard/loads/[id]/edit/page.tsx
+++ b/main/src/app/dashboard/loads/[id]/edit/page.tsx
@@ -1,0 +1,17 @@
+import { notFound } from 'next/navigation';
+import { getLoadById } from '@/lib/fetchers/loads';
+import LoadForm from '@/features/dispatch/components/LoadForm';
+
+interface Params { params: { id: string } }
+
+export default async function EditLoadPage({ params }: Params) {
+  const id = Number(params.id);
+  const load = await getLoadById(id);
+  if (!load) return notFound();
+
+  return (
+    <div className="p-8">
+      <LoadForm load={load} />
+    </div>
+  );
+}

--- a/main/src/app/dashboard/loads/[id]/page.tsx
+++ b/main/src/app/dashboard/loads/[id]/page.tsx
@@ -1,0 +1,44 @@
+import { notFound } from 'next/navigation';
+import Link from 'next/link';
+import { getLoadById } from '@/lib/fetchers/loads';
+import { Button } from '@/components/ui/button';
+import { updateLoadStatus } from '@/lib/actions/loads';
+import { loadStatusEnum } from '@/lib/schema';
+
+interface Params { params: { id: string } }
+
+export default async function LoadDetailPage({ params }: Params) {
+  const id = Number(params.id);
+  const load = await getLoadById(id);
+  if (!load) return notFound();
+
+  async function setStatus(formData: FormData) {
+    'use server';
+    const status = formData.get('status') as typeof loadStatusEnum.enumValues[number];
+    return updateLoadStatus(id, status);
+  }
+
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Load #{load.loadNumber}</h1>
+        <Link href={`/dashboard/loads/${id}/edit`}>
+          <Button variant="outline">Edit</Button>
+        </Link>
+      </div>
+      <div className="space-y-2 text-sm">
+        <p><strong>Status:</strong> {load.status}</p>
+        <p><strong>Pickup:</strong> {load.pickupLocation.address}</p>
+        <p><strong>Delivery:</strong> {load.deliveryLocation.address}</p>
+      </div>
+      <form action={setStatus} className="space-x-2">
+        <select name="status" defaultValue={load.status} className="border rounded h-9 px-3">
+          {['pending','assigned','in_transit','delivered','cancelled'].map(s => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+        <Button type="submit">Update Status</Button>
+      </form>
+    </div>
+  );
+}

--- a/main/src/app/dashboard/loads/new/page.tsx
+++ b/main/src/app/dashboard/loads/new/page.tsx
@@ -1,0 +1,17 @@
+import LoadForm from '@/features/dispatch/components/LoadForm';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function NewLoadPage() {
+  return (
+    <div className="p-8">
+      <Card>
+        <CardHeader>
+          <CardTitle>Create Load</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <LoadForm />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/main/src/app/dashboard/loads/page.tsx
+++ b/main/src/app/dashboard/loads/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { getCurrentUser } from '@/lib/rbac';
+import { getAllLoads } from '@/lib/fetchers/loads';
+import LoadSummary from '@/features/dispatch/components/LoadSummary';
+import { Button } from '@/components/ui/button';
+
+export default async function LoadsPage() {
+  const user = await getCurrentUser();
+  if (!user) return null;
+  const loads = await getAllLoads(user.orgId);
+  return (
+    <div className="p-8 space-y-6">
+      <div className="flex justify-between">
+        <h1 className="text-2xl font-bold">Loads</h1>
+        <Link href="/dashboard/loads/new">
+          <Button>Create Load</Button>
+        </Link>
+      </div>
+      <div className="grid gap-4">
+        {loads.map(l => (
+          <LoadSummary key={l.id} load={l} />
+        ))}
+        {loads.length === 0 && <p>No loads found.</p>}
+      </div>
+    </div>
+  );
+}

--- a/main/src/features/dispatch/components/LoadForm.tsx
+++ b/main/src/features/dispatch/components/LoadForm.tsx
@@ -1,0 +1,51 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { createLoad, updateLoad } from '@/lib/actions/loads';
+import type { Load } from '@/types/loads';
+
+interface Props {
+  load?: Load;
+}
+
+export default function LoadForm({ load }: Props) {
+  const action = load ? updateLoad.bind(null, load.id) : createLoad;
+  return (
+    <form action={action} className="space-y-4">
+      {load && <input type="hidden" name="id" value={load.id} />}
+      <div className="space-y-2">
+        <Label htmlFor="loadNumber">Load #</Label>
+        <Input id="loadNumber" name="loadNumber" defaultValue={load?.loadNumber ?? ''} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="pickupAddress">Pickup Address</Label>
+        <Input id="pickupAddress" name="pickupAddress" defaultValue={load?.pickupLocation.address ?? ''} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="pickupTime">Pickup Time</Label>
+        <Input id="pickupTime" name="pickupTime" type="datetime-local" defaultValue={load?.pickupLocation.datetime ?? ''} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="deliveryAddress">Delivery Address</Label>
+        <Input id="deliveryAddress" name="deliveryAddress" defaultValue={load?.deliveryLocation.address ?? ''} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="deliveryTime">Delivery Time</Label>
+        <Input id="deliveryTime" name="deliveryTime" type="datetime-local" defaultValue={load?.deliveryLocation.datetime ?? ''} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="weight">Weight (lbs)</Label>
+        <Input id="weight" name="weight" type="number" defaultValue={load?.weight ?? undefined} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="rate">Rate (cents)</Label>
+        <Input id="rate" name="rate" type="number" defaultValue={load?.rate ?? undefined} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="notes">Notes</Label>
+        <textarea id="notes" name="notes" defaultValue={load?.notes ?? ''} className="border rounded w-full p-2" />
+      </div>
+      <Button type="submit" className="w-full">{load ? 'Update Load' : 'Create Load'}</Button>
+    </form>
+  );
+}

--- a/main/src/features/dispatch/components/LoadSummary.tsx
+++ b/main/src/features/dispatch/components/LoadSummary.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+import type { Load } from '@/types/loads';
+
+export default function LoadSummary({ load }: { load: Load }) {
+  return (
+    <div className="border rounded p-4 space-y-1">
+      <div className="font-medium">#{load.loadNumber}</div>
+      <div className="text-sm text-muted-foreground">Status: {load.status}</div>
+      <Link href={`/dashboard/loads/${load.id}`} className="text-blue-600 text-sm">Details</Link>
+    </div>
+  );
+}

--- a/main/src/lib/actions/__tests__/loads.test.ts
+++ b/main/src/lib/actions/__tests__/loads.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createLoad } from '../loads';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: () => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }),
+  },
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })),
+  getCurrentUser: vi.fn(async () => ({ id: '1', orgId: 1, role: 'DISPATCHER' })),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { LOAD_CREATE: 'load.create', LOAD_STATUS_CHANGE: 'load.status' },
+  AUDIT_RESOURCES: { LOAD: 'load' },
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+describe('createLoad', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates load with valid data', async () => {
+    const data = new FormData();
+    data.set('loadNumber', 'L100');
+    data.set('pickupAddress', 'A');
+    data.set('pickupTime', '2024-01-01T10:00');
+    data.set('deliveryAddress', 'B');
+    data.set('deliveryTime', '2024-01-02T10:00');
+    const result = await createLoad(data);
+    expect(result.success).toBe(true);
+  });
+
+  it('fails with invalid data', async () => {
+    const data = new FormData();
+    data.set('loadNumber', '');
+    await expect(createLoad(data)).rejects.toThrow();
+  });
+});

--- a/main/src/lib/actions/compliance.test.ts
+++ b/main/src/lib/actions/compliance.test.ts
@@ -9,3 +9,35 @@ describe('generateUniqueFilename', () => {
     expect(a.endsWith('.pdf')).toBe(true);
   });
 });
+import { uploadDocumentsAction } from './compliance';
+import { vi, beforeEach } from 'vitest';
+
+vi.mock('@/lib/db', () => ({
+  db: { insert: () => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) },
+}));
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })),
+}));
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { DOCUMENT_UPLOAD: 'doc.upload' },
+  AUDIT_RESOURCES: { DOCUMENT: 'document' },
+}));
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+vi.mock('fs', () => ({ promises: { mkdir: vi.fn(), writeFile: vi.fn() } }));
+
+describe('uploadDocumentsAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('handles multiple files', async () => {
+    const formData = new FormData();
+    formData.set('category', 'driver');
+    formData.append('documents', new File(['a'], 'a.txt', { type: 'text/plain' }));
+    formData.append('documents', new File(['b'], 'b.txt', { type: 'text/plain' }));
+    const result = await uploadDocumentsAction(formData);
+    expect(result.success).toBe(true);
+    expect(result.documents.length).toBe(2);
+  });
+});

--- a/main/src/lib/actions/loads.ts
+++ b/main/src/lib/actions/loads.ts
@@ -1,0 +1,147 @@
+'use server';
+
+import { db } from '@/lib/db';
+import { loads, drivers } from '@/lib/schema';
+import { loadFormSchema } from '@/lib/validation/load';
+import { AUDIT_ACTIONS, AUDIT_RESOURCES, createAuditLog } from '@/lib/audit';
+import { requirePermission, getCurrentUser } from '@/lib/rbac';
+import { loadStatusEnum } from '@/lib/schema';
+import { revalidatePath } from 'next/cache';
+import { eq, and } from 'drizzle-orm';
+import { SystemRoles } from '@/types/rbac';
+
+export async function createLoad(formData: FormData) {
+  const user = await requirePermission('org:dispatcher:create_edit_loads');
+  const input = loadFormSchema.parse({
+    loadNumber: formData.get('loadNumber'),
+    pickupAddress: formData.get('pickupAddress'),
+    pickupTime: formData.get('pickupTime'),
+    deliveryAddress: formData.get('deliveryAddress'),
+    deliveryTime: formData.get('deliveryTime'),
+    weight: formData.get('weight'),
+    rate: formData.get('rate'),
+    notes: formData.get('notes'),
+  });
+
+  const [load] = await db.insert(loads).values({
+    orgId: user.orgId,
+    loadNumber: input.loadNumber,
+    pickupLocation: {
+      address: input.pickupAddress,
+      lat: 0,
+      lng: 0,
+      datetime: input.pickupTime,
+    },
+    deliveryLocation: {
+      address: input.deliveryAddress,
+      lat: 0,
+      lng: 0,
+      datetime: input.deliveryTime,
+    },
+    weight: input.weight,
+    rate: input.rate,
+    notes: input.notes,
+    createdById: parseInt(user.id),
+  }).returning();
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.LOAD_CREATE,
+    resource: AUDIT_RESOURCES.LOAD,
+    resourceId: load.id.toString(),
+    details: { createdBy: user.id },
+  });
+
+  revalidatePath('/dashboard/loads');
+  return { success: true, load };
+}
+
+export async function updateLoad(id: number, formData: FormData) {
+  const user = await requirePermission('org:dispatcher:create_edit_loads');
+  const input = loadFormSchema.parse({
+    loadNumber: formData.get('loadNumber'),
+    pickupAddress: formData.get('pickupAddress'),
+    pickupTime: formData.get('pickupTime'),
+    deliveryAddress: formData.get('deliveryAddress'),
+    deliveryTime: formData.get('deliveryTime'),
+    weight: formData.get('weight'),
+    rate: formData.get('rate'),
+    notes: formData.get('notes'),
+  });
+
+  const [load] = await db
+    .update(loads)
+    .set({
+      loadNumber: input.loadNumber,
+      pickupLocation: {
+        address: input.pickupAddress,
+        lat: 0,
+        lng: 0,
+        datetime: input.pickupTime,
+      },
+      deliveryLocation: {
+        address: input.deliveryAddress,
+        lat: 0,
+        lng: 0,
+        datetime: input.deliveryTime,
+      },
+      weight: input.weight,
+      rate: input.rate,
+      notes: input.notes,
+      updatedAt: new Date(),
+    })
+    .where(eq(loads.id, id))
+    .returning();
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.LOAD_UPDATE,
+    resource: AUDIT_RESOURCES.LOAD,
+    resourceId: id.toString(),
+    details: { updatedBy: user.id },
+  });
+
+  revalidatePath('/dashboard/loads');
+  revalidatePath(`/dashboard/loads/${id}`);
+  return { success: true, load };
+}
+
+export async function updateLoadStatus(loadId: number, status: typeof loadStatusEnum.enumValues[number]) {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new Error('Unauthorized');
+  }
+
+  const [load] = await db
+    .select()
+    .from(loads)
+    .where(and(eq(loads.id, loadId), eq(loads.orgId, user.orgId)));
+
+  if (!load) {
+    return { success: false, error: 'Load not found' };
+  }
+
+  if (user.role === SystemRoles.DRIVER) {
+    const [driver] = await db
+      .select()
+      .from(drivers)
+      .where(eq(drivers.userId, parseInt(user.id)));
+    if (!driver || load.assignedDriverId !== driver.id) {
+      return { success: false, error: 'Not authorized to update this load' };
+    }
+  }
+
+  const [updatedLoad] = await db
+    .update(loads)
+    .set({ status, updatedAt: new Date() })
+    .where(eq(loads.id, loadId))
+    .returning();
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.LOAD_STATUS_CHANGE,
+    resource: AUDIT_RESOURCES.LOAD,
+    resourceId: loadId.toString(),
+    details: { oldStatus: load.status, newStatus: status, updatedBy: user.id },
+  });
+
+  revalidatePath('/dashboard/loads');
+  return { success: true, load: updatedLoad };
+}

--- a/main/src/lib/fetchers/loads.ts
+++ b/main/src/lib/fetchers/loads.ts
@@ -1,0 +1,13 @@
+import { db } from '@/lib/db';
+import { loads } from '@/lib/schema';
+import { eq } from 'drizzle-orm';
+import type { Load } from '@/types/loads';
+
+export async function getAllLoads(orgId: number): Promise<Load[]> {
+  return db.select().from(loads).where(eq(loads.orgId, orgId));
+}
+
+export async function getLoadById(id: number): Promise<Load | undefined> {
+  const [load] = await db.select().from(loads).where(eq(loads.id, id));
+  return load;
+}

--- a/main/src/lib/validation/load.ts
+++ b/main/src/lib/validation/load.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const loadFormSchema = z.object({
+  loadNumber: z.string().min(1),
+  pickupAddress: z.string().min(1),
+  pickupTime: z.string().min(1),
+  deliveryAddress: z.string().min(1),
+  deliveryTime: z.string().min(1),
+  weight: z.coerce.number().int().positive().optional(),
+  rate: z.coerce.number().int().positive().optional(),
+  notes: z.string().optional(),
+});
+
+export type LoadFormInput = z.infer<typeof loadFormSchema>;

--- a/main/src/types/loads.ts
+++ b/main/src/types/loads.ts
@@ -1,0 +1,27 @@
+export interface Load {
+  id: number;
+  orgId: number;
+  loadNumber: string;
+  status: 'pending' | 'assigned' | 'in_transit' | 'delivered' | 'cancelled';
+  assignedDriverId: number | null;
+  assignedVehicleId: number | null;
+  pickupLocation: {
+    address: string;
+    lat: number;
+    lng: number;
+    datetime: string;
+  };
+  deliveryLocation: {
+    address: string;
+    lat: number;
+    lng: number;
+    datetime: string;
+  };
+  weight: number | null;
+  distance: number | null;
+  rate: number | null;
+  notes: string | null;
+  createdById: number;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/wiki/Tasks/compliance-issue-01.md
+++ b/wiki/Tasks/compliance-issue-01.md
@@ -16,10 +16,10 @@ Build the document upload system for the Compliance module. This includes multi-
 - See [Official Docs](../Official-Docs.md) for file upload and storage best practices.
 
 ## Checklist
-- [ ] Multi-file upload UI and logic
-- [ ] Batch upload support
-- [ ] Document categorization
-- [ ] Tests and documentation
+- [x] Multi-file upload UI and logic
+- [x] Batch upload support
+- [x] Document categorization
+- [x] Tests and documentation
 
 ## Verification
 - Upload multiple documents and verify correct categorization.

--- a/wiki/Tasks/dispatch-issue-01.md
+++ b/wiki/Tasks/dispatch-issue-01.md
@@ -16,10 +16,10 @@ Build the load management features for the Dispatch module. This includes load c
 - See [Official Docs](../Official-Docs.md) for Next.js and Drizzle ORM usage.
 
 ## Checklist
-- [ ] Load creation form and logic
-- [ ] Load editing interface
-- [ ] Status tracking and exception handling
-- [ ] Tests and documentation
+ - [x] Load creation form and logic
+ - [x] Load editing interface
+ - [x] Status tracking and exception handling
+ - [x] Tests and documentation
 
 ## Verification
 - Create, edit, and update load status; verify all flows.


### PR DESCRIPTION
Closes #41

## Summary
- implement load CRUD actions and forms
- add LoadSummary component and pages for load management
- support multi-file document uploads with tests
- update wiki tasks for compliance and dispatch

## Checklist
- [x] Passes CI
- [x] Updates docs
- [ ] Notifies milestone

------
https://chatgpt.com/codex/tasks/task_e_68632cef270c8327b7da5ad6a10e0872