### PR TITLE
feat: add operational kpi analytics

### DIFF
--- a/main/src/app/analytics/page.tsx
+++ b/main/src/app/analytics/page.tsx
@@ -1,5 +1,6 @@
 import { getCurrentUser } from '@/lib/rbac';
 import FleetUtilization from '@/features/analytics/components/FleetUtilization';
+import OperationalKPIs from '@/features/analytics/components/OperationalKPIs';
 import { redirect } from 'next/navigation';
 
 export default async function AnalyticsPage() {
@@ -11,6 +12,7 @@ export default async function AnalyticsPage() {
       <div className="max-w-4xl mx-auto space-y-6">
         <h1 className="text-3xl font-bold">Analytics Dashboard</h1>
         <FleetUtilization orgId={user.orgId} />
+        <OperationalKPIs orgId={user.orgId} />
       </div>
     </div>
   );

--- a/main/src/features/analytics/components/OperationalKPIs.tsx
+++ b/main/src/features/analytics/components/OperationalKPIs.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card';
+import {
+  fetchOnTimeDeliveryRate,
+  fetchCostPerMile,
+} from '@/lib/fetchers/analytics';
+
+interface Props {
+  orgId: number;
+}
+
+export default async function OperationalKPIs({ orgId }: Props) {
+  const [onTime, cost] = await Promise.all([
+    fetchOnTimeDeliveryRate(orgId),
+    fetchCostPerMile(orgId),
+  ]);
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>On-time Delivery</CardTitle>
+          <CardDescription>Percentage of loads delivered by scheduled time</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span>Total Delivered</span>
+            <span>{onTime.totalDelivered}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span>On-Time Deliveries</span>
+            <span>{onTime.onTimeDeliveries}</span>
+          </div>
+          <div className="flex justify-between font-medium">
+            <span>On-Time Rate</span>
+            <span>{(onTime.onTimeRate * 100).toFixed(0)}%</span>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost per Mile</CardTitle>
+          <CardDescription>Average cost incurred per mile</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span>Total Miles</span>
+            <span>{cost.totalMiles}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span>Total Cost ($)</span>
+            <span>{(cost.totalCost / 100).toFixed(2)}</span>
+          </div>
+          <div className="flex justify-between font-medium">
+            <span>Cost/Mile ($)</span>
+            <span>{cost.costPerMile.toFixed(2)}</span>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/main/tests/analytics/operational-kpis.test.ts
+++ b/main/tests/analytics/operational-kpis.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, vi } from 'vitest';
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }));
+vi.mock('../../src/lib/fetchers/analytics');
+import OperationalKPIs from '../../src/features/analytics/components/OperationalKPIs';
+import * as fetchers from '../../src/lib/fetchers/analytics';
+
+describe('OperationalKPIs component', () => {
+  it('renders KPI cards', async () => {
+    vi.mocked(fetchers.fetchOnTimeDeliveryRate).mockResolvedValue({
+      totalDelivered: 10,
+      onTimeDeliveries: 8,
+      onTimeRate: 0.8,
+    });
+    vi.mocked(fetchers.fetchCostPerMile).mockResolvedValue({
+      totalCost: 10000,
+      totalMiles: 500,
+      costPerMile: 20,
+    });
+
+    const element = await OperationalKPIs({ orgId: 1 });
+    const html = renderToString(element);
+    expect(html).toContain('On-time Delivery');
+    expect(html).toContain('Cost per Mile');
+  });
+});

--- a/main/tests/analytics/operational.test.ts
+++ b/main/tests/analytics/operational.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }));
+import { calculateOnTimeRate, calcCostPerMile } from '../../src/lib/fetchers/analytics';
+
+describe('calculateOnTimeRate', () => {
+  it('returns 0 when total is 0', () => {
+    expect(calculateOnTimeRate(0, 5)).toBe(0);
+  });
+
+  it('calculates rate correctly', () => {
+    expect(calculateOnTimeRate(10, 8)).toBeCloseTo(0.8, 2);
+  });
+});
+
+describe('calcCostPerMile', () => {
+  it('returns 0 when miles are 0', () => {
+    expect(calcCostPerMile(1000, 0)).toBe(0);
+  });
+
+  it('calculates cost per mile', () => {
+    expect(calcCostPerMile(10000, 500)).toBeCloseTo(20, 2);
+  });
+});


### PR DESCRIPTION
Closes #26

### Summary
- add fetchers for on-time delivery and cost-per-mile KPIs
- create OperationalKPIs dashboard component
- show KPIs on analytics page
- add unit and integration tests for KPI calculations and display

### Checklist
- [x] Passes lint
- [ ] Passes typecheck
- [x] Passes analytics tests


------
https://chatgpt.com/codex/tasks/task_e_6863436965d0832790781a27b91c2a80