### PR TITLE
feat: add fleet dashboard UI

### DIFF
--- a/main/drizzle/0003_fleet_overview.sql
+++ b/main/drizzle/0003_fleet_overview.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "vehicles" ADD COLUMN "next_maintenance_date" timestamp;
+ALTER TABLE "vehicles" ADD COLUMN "next_inspection_date" timestamp;

--- a/main/drizzle/meta/0003_snapshot.json
+++ b/main/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,960 @@
+{
+
+  "id": "33d93fa5-737c-4216-bad8-7a316b737385",
+  "prevId": "feeb5f89-9bb7-461a-98f8-3f6ab505935b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.audit_logs": {
+      "name": "audit_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "varchar(45)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "audit_logs_org_id_organizations_id_fk": {
+          "name": "audit_logs_org_id_organizations_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "audit_logs_user_id_users_id_fk": {
+          "name": "audit_logs_user_id_users_id_fk",
+          "tableFrom": "audit_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.documents": {
+      "name": "documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "uploaded_by_id": {
+          "name": "uploaded_by_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "load_id": {
+          "name": "load_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "driver_id": {
+          "name": "driver_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_url": {
+          "name": "file_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_type": {
+          "name": "file_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_type": {
+          "name": "document_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_compliant": {
+          "name": "is_compliant",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "reviewed_by_id": {
+          "name": "reviewed_by_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "documents_org_id_organizations_id_fk": {
+          "name": "documents_org_id_organizations_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_uploaded_by_id_users_id_fk": {
+          "name": "documents_uploaded_by_id_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_load_id_loads_id_fk": {
+          "name": "documents_load_id_loads_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "loads",
+          "columnsFrom": [
+            "load_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_driver_id_drivers_id_fk": {
+          "name": "documents_driver_id_drivers_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "documents_reviewed_by_id_users_id_fk": {
+          "name": "documents_reviewed_by_id_users_id_fk",
+          "tableFrom": "documents",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drivers": {
+      "name": "drivers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_number": {
+          "name": "license_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_expiry": {
+          "name": "license_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dot_number": {
+          "name": "dot_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "current_location": {
+          "name": "current_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drivers_user_id_users_id_fk": {
+          "name": "drivers_user_id_users_id_fk",
+          "tableFrom": "drivers",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.loads": {
+      "name": "loads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "load_number": {
+          "name": "load_number",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "load_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "assigned_driver_id": {
+          "name": "assigned_driver_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_vehicle_id": {
+          "name": "assigned_vehicle_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pickup_location": {
+          "name": "pickup_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_location": {
+          "name": "delivery_location",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "weight": {
+          "name": "weight",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance": {
+          "name": "distance",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rate": {
+          "name": "rate",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "loads_org_id_organizations_id_fk": {
+          "name": "loads_org_id_organizations_id_fk",
+          "tableFrom": "loads",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "loads_assigned_driver_id_drivers_id_fk": {
+          "name": "loads_assigned_driver_id_drivers_id_fk",
+          "tableFrom": "loads",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "assigned_driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "loads_assigned_vehicle_id_vehicles_id_fk": {
+          "name": "loads_assigned_vehicle_id_vehicles_id_fk",
+          "tableFrom": "loads",
+          "tableTo": "vehicles",
+          "columnsFrom": [
+            "assigned_vehicle_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "loads_created_by_id_users_id_fk": {
+          "name": "loads_created_by_id_users_id_fk",
+          "tableFrom": "loads",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'trialing'"
+        },
+        "subscription_plan": {
+          "name": "subscription_plan",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'basic'"
+        },
+        "max_users": {
+          "name": "max_users",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_clerk_org_id_unique": {
+          "name": "organizations_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        },
+        "organizations_slug_unique": {
+          "name": "organizations_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "system_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEMBER'"
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_org_id_organizations_id_fk": {
+          "name": "users_org_id_organizations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.vehicles": {
+      "name": "vehicles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vin": {
+          "name": "vin",
+          "type": "varchar(17)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "license_plate": {
+          "name": "license_plate",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "make": {
+          "name": "make",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "vehicle_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capacity": {
+          "name": "capacity",
+
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insurance_provider": {
+          "name": "insurance_provider",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "insurance_policy_number": {
+          "name": "insurance_policy_number",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner_info": {
+          "name": "owner_info",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "photo_url": {
+          "name": "photo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_maintenance_date": {
+          "name": "next_maintenance_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_inspection_date": {
+          "name": "next_inspection_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "vehicle_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ACTIVE'"
+        },
+
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "current_driver_id": {
+          "name": "current_driver_id",
+          "type": "serial",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "vehicles_org_id_organizations_id_fk": {
+          "name": "vehicles_org_id_organizations_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "organizations",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "vehicles_current_driver_id_drivers_id_fk": {
+          "name": "vehicles_current_driver_id_drivers_id_fk",
+          "tableFrom": "vehicles",
+          "tableTo": "drivers",
+          "columnsFrom": [
+            "current_driver_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.load_status": {
+      "name": "load_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "assigned",
+        "in_transit",
+        "delivered",
+        "cancelled"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "cancelled",
+        "past_due",
+        "trialing"
+      ]
+    },
+    "public.system_role": {
+      "name": "system_role",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "DISPATCHER",
+        "DRIVER",
+        "COMPLIANCE",
+        "MEMBER"
+      ]
+    },
+    "public.vehicle_status": {
+      "name": "vehicle_status",
+      "schema": "public",
+      "values": [
+        "ACTIVE",
+        "MAINTENANCE",
+        "RETIRED"
+      ]
+    },
+    "public.vehicle_type": {
+      "name": "vehicle_type",
+      "schema": "public",
+      "values": [
+        "TRACTOR",
+        "TRAILER",
+        "VAN",
+        "CAR",
+        "OTHER"
+      ]
+
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/main/drizzle/meta/_journal.json
+++ b/main/drizzle/meta/_journal.json
@@ -23,6 +23,13 @@
       "when": 1751319831435,
       "tag": "0002_useful_patriot",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1751320000000,
+      "tag": "0003_fleet_overview",
+      "breakpoints": true
     }
   ]
 }

--- a/main/src/app/dashboard/vehicles/page.tsx
+++ b/main/src/app/dashboard/vehicles/page.tsx
@@ -1,13 +1,12 @@
 import { getCurrentUser } from '@/lib/rbac'
-import { getAllVehicles } from '@/lib/fetchers/vehicles'
+import FleetDashboard from '@/features/vehicles/components/FleetDashboard'
+import VehicleList from '@/features/vehicles/components/VehicleList'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 
 export default async function VehiclesPage() {
   const user = await getCurrentUser()
   if (!user) return null
-  const vehicles = await getAllVehicles(user.orgId)
-
   return (
     <div className="p-8 space-y-6">
       <div className="flex justify-between">
@@ -16,16 +15,8 @@ export default async function VehiclesPage() {
           <Button>Add Vehicle</Button>
         </Link>
       </div>
-      <div className="grid gap-4">
-        {vehicles.map(v => (
-          <div key={v.id} className="border rounded p-4 space-y-1">
-            <div className="font-medium">{v.make} {v.model} ({v.year})</div>
-            <div className="text-sm text-muted-foreground">VIN: {v.vin}</div>
-            <div className="text-sm text-muted-foreground">Status: {v.status}</div>
-            <Link href={`/dashboard/vehicles/${v.id}/edit`} className="text-blue-600 text-sm">Edit</Link>
-          </div>
-        ))}
-      </div>
+      <FleetDashboard orgId={user.orgId} />
+      <VehicleList orgId={user.orgId} />
     </div>
   )
 }

--- a/main/src/features/vehicles/VehicleForm.tsx
+++ b/main/src/features/vehicles/VehicleForm.tsx
@@ -57,6 +57,24 @@ export default function VehicleForm({ vehicle }: VehicleFormProps) {
         <Input id="photoUrl" name="photoUrl" defaultValue={vehicle?.photoUrl ?? ''} />
       </div>
       <div className="space-y-2">
+        <Label htmlFor="nextMaintenanceDate">Next Maintenance</Label>
+        <Input
+          id="nextMaintenanceDate"
+          name="nextMaintenanceDate"
+          type="date"
+          defaultValue={vehicle?.nextMaintenanceDate?.toISOString().slice(0, 10) ?? ''}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="nextInspectionDate">Next Inspection</Label>
+        <Input
+          id="nextInspectionDate"
+          name="nextInspectionDate"
+          type="date"
+          defaultValue={vehicle?.nextInspectionDate?.toISOString().slice(0, 10) ?? ''}
+        />
+      </div>
+      <div className="space-y-2">
         <Label htmlFor="status">Status</Label>
         <select id="status" name="status" defaultValue={vehicle?.status ?? 'ACTIVE'} className="border rounded h-9 px-3">
           <option value="ACTIVE">Active</option>

--- a/main/src/features/vehicles/components/FleetDashboard.tsx
+++ b/main/src/features/vehicles/components/FleetDashboard.tsx
@@ -40,12 +40,14 @@ export default async function FleetDashboard({ orgId }: Props) {
       <Card>
         <CardHeader>
           <CardTitle>Maintenance Due</CardTitle>
+          <CardDescription>Vehicles scheduled for maintenance</CardDescription>
         </CardHeader>
         <CardContent className="text-2xl font-bold">{metrics.maintenanceDue}</CardContent>
       </Card>
       <Card>
         <CardHeader>
           <CardTitle>Inspection Due</CardTitle>
+          <CardDescription>Vehicles requiring inspection</CardDescription>
         </CardHeader>
         <CardContent className="text-2xl font-bold">{metrics.inspectionDue}</CardContent>
       </Card>

--- a/main/src/features/vehicles/components/FleetDashboard.tsx
+++ b/main/src/features/vehicles/components/FleetDashboard.tsx
@@ -1,0 +1,54 @@
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card'
+import { getFleetOverview } from '@/lib/fetchers/vehicles'
+
+interface Props {
+  orgId: number
+}
+
+export default async function FleetDashboard({ orgId }: Props) {
+  const metrics = await getFleetOverview(orgId)
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      <Card>
+        <CardHeader>
+          <CardTitle>Fleet Size</CardTitle>
+          <CardDescription>Total vehicles in your organization</CardDescription>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{metrics.total}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Active</CardTitle>
+          <CardDescription>Vehicles currently operational</CardDescription>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{metrics.active}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>In Maintenance</CardTitle>
+          <CardDescription>Vehicles under maintenance</CardDescription>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{metrics.maintenance}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Retired</CardTitle>
+          <CardDescription>Inactive vehicles</CardDescription>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{metrics.retired}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Maintenance Due</CardTitle>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{metrics.maintenanceDue}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Inspection Due</CardTitle>
+        </CardHeader>
+        <CardContent className="text-2xl font-bold">{metrics.inspectionDue}</CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/main/src/features/vehicles/components/VehicleList.tsx
+++ b/main/src/features/vehicles/components/VehicleList.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { getVehicleList } from '@/lib/fetchers/vehicles'
+import { bulkUpdateVehicleStatus } from '@/lib/actions/vehicles'
+
+interface Props {
+  orgId: number
+  status?: 'ACTIVE' | 'MAINTENANCE' | 'RETIRED'
+  sort?: 'make' | 'model' | 'year' | 'status' | 'vin'
+}
+
+export default async function VehicleList({ orgId, status, sort }: Props) {
+  const vehicles = await getVehicleList(orgId, sort ?? 'id', status)
+
+  async function retireSelected(formData: FormData) {
+    'use server'
+    const ids = formData.getAll('vehicleId').map(id => Number(id))
+    await bulkUpdateVehicleStatus(ids, 'RETIRED')
+  }
+
+  return (
+    <form action={retireSelected} className="space-y-4">
+      <table className="w-full text-sm">
+        <thead className="text-left">
+          <tr>
+            <th></th>
+            <th>Make</th>
+            <th>Model</th>
+            <th>Year</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {vehicles.map(v => (
+            <tr key={v.id} className="border-t">
+              <td>
+                <input type="checkbox" name="vehicleId" value={v.id} />
+              </td>
+              <td>{v.make}</td>
+              <td>{v.model}</td>
+              <td>{v.year}</td>
+              <td>{v.status}</td>
+              <td>
+                <Link href={`/dashboard/vehicles/${v.id}/edit`} className="text-blue-600">Edit</Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <Button type="submit" variant="destructive">Retire Selected</Button>
+    </form>
+  )
+}

--- a/main/src/lib/actions/vehicles.ts
+++ b/main/src/lib/actions/vehicles.ts
@@ -69,7 +69,7 @@ export async function updateVehicle(id: number, data: Partial<VehicleInput>) {
 }
 
 export async function bulkUpdateVehicleStatus(ids: number[], status: 'ACTIVE' | 'MAINTENANCE' | 'RETIRED') {
-  const user = await requirePermission('org:admin:manage_users_and_roles')
+  const user = await requirePermission('org:admin:manage_vehicles')
   await db
     .update(vehicles)
     .set({ status, updatedAt: new Date() })

--- a/main/src/lib/actions/vehicles.ts
+++ b/main/src/lib/actions/vehicles.ts
@@ -5,7 +5,7 @@ import { vehicles } from '@/lib/schema'
 import { requirePermission } from '@/lib/rbac'
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_RESOURCES } from '@/lib/audit'
 import { revalidatePath } from 'next/cache'
-import { eq } from 'drizzle-orm'
+import { eq, inArray } from 'drizzle-orm'
 import { z } from 'zod'
 
 export const vehicleInputSchema = z.object({
@@ -20,6 +20,8 @@ export const vehicleInputSchema = z.object({
   insurancePolicyNumber: z.string().optional(),
   ownerInfo: z.string().optional(),
   photoUrl: z.string().optional(),
+  nextMaintenanceDate: z.coerce.date().optional(),
+  nextInspectionDate: z.coerce.date().optional(),
   status: z.enum(['ACTIVE','MAINTENANCE','RETIRED']).optional(),
 })
 export type VehicleInput = z.infer<typeof vehicleInputSchema>
@@ -64,4 +66,22 @@ export async function updateVehicle(id: number, data: Partial<VehicleInput>) {
 
   revalidatePath('/dashboard/vehicles')
   return { success: true, vehicle }
+}
+
+export async function bulkUpdateVehicleStatus(ids: number[], status: 'ACTIVE' | 'MAINTENANCE' | 'RETIRED') {
+  const user = await requirePermission('org:admin:manage_users_and_roles')
+  await db
+    .update(vehicles)
+    .set({ status, updatedAt: new Date() })
+    .where(inArray(vehicles.id, ids))
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.VEHICLE_UPDATE,
+    resource: AUDIT_RESOURCES.VEHICLE,
+    resourceId: ids.join(','),
+    details: { updatedBy: user.id, status },
+  })
+
+  revalidatePath('/dashboard/vehicles')
+  return { success: true }
 }

--- a/main/src/lib/fetchers/vehicles.ts
+++ b/main/src/lib/fetchers/vehicles.ts
@@ -1,9 +1,72 @@
 import { db } from '@/lib/db'
 import { vehicles } from '@/lib/schema'
-import { eq } from 'drizzle-orm'
+import { eq, sql } from 'drizzle-orm'
 
 export async function getAllVehicles(orgId: number) {
   return db.select().from(vehicles).where(eq(vehicles.orgId, orgId))
+}
+
+export interface FleetOverview {
+  total: number
+  active: number
+  maintenance: number
+  retired: number
+  maintenanceDue: number
+  inspectionDue: number
+}
+
+export async function getFleetOverview(orgId: number): Promise<FleetOverview> {
+  const totalRes = await db.execute<{ count: number }>(sql`
+    SELECT count(*)::int AS count FROM vehicles WHERE org_id = ${orgId}
+  `)
+  const statusRes = await db.execute<{ status: string; count: number }>(sql`
+    SELECT status, count(*)::int AS count FROM vehicles
+    WHERE org_id = ${orgId}
+    GROUP BY status
+  `)
+  const maintDueRes = await db.execute<{ count: number }>(sql`
+    SELECT count(*)::int AS count FROM vehicles
+    WHERE org_id = ${orgId} AND next_maintenance_date <= now()
+  `)
+  const inspDueRes = await db.execute<{ count: number }>(sql`
+    SELECT count(*)::int AS count FROM vehicles
+    WHERE org_id = ${orgId} AND next_inspection_date <= now()
+  `)
+
+  const statusCounts = statusRes.rows.reduce<Record<string, number>>((acc, r) => {
+    acc[r.status] = r.count
+    return acc
+  }, {})
+
+  return {
+    total: totalRes.rows[0]?.count ?? 0,
+    active: statusCounts.ACTIVE ?? 0,
+    maintenance: statusCounts.MAINTENANCE ?? 0,
+    retired: statusCounts.RETIRED ?? 0,
+    maintenanceDue: maintDueRes.rows[0]?.count ?? 0,
+    inspectionDue: inspDueRes.rows[0]?.count ?? 0,
+  }
+}
+
+export async function getVehicleList(
+  orgId: number,
+  sort: keyof typeof vehicles | 'id' = 'id',
+  status?: 'ACTIVE' | 'MAINTENANCE' | 'RETIRED'
+) {
+  let query = db.select().from(vehicles).where(eq(vehicles.orgId, orgId))
+  if (status) {
+    query = query.where(eq(vehicles.status, status))
+  }
+  const columnMap = {
+    id: vehicles.id,
+    make: vehicles.make,
+    model: vehicles.model,
+    year: vehicles.year,
+    status: vehicles.status,
+    vin: vehicles.vin,
+  } as const
+  const orderCol = columnMap[sort] ?? vehicles.id
+  return query.orderBy(orderCol)
 }
 
 export async function getVehicleById(id: number) {

--- a/main/src/lib/schema.ts
+++ b/main/src/lib/schema.ts
@@ -67,6 +67,8 @@ export const vehicles = pgTable('vehicles', {
   insurancePolicyNumber: varchar('insurance_policy_number', { length: 100 }),
   ownerInfo: varchar('owner_info', { length: 255 }),
   photoUrl: text('photo_url'),
+  nextMaintenanceDate: timestamp('next_maintenance_date'),
+  nextInspectionDate: timestamp('next_inspection_date'),
   status: vehicleStatusEnum('status').default('ACTIVE').notNull(),
 
   isActive: boolean('is_active').default(true).notNull(),

--- a/main/src/types/vehicles.ts
+++ b/main/src/types/vehicles.ts
@@ -1,0 +1,22 @@
+export interface Vehicle {
+  id: number;
+  orgId: number;
+  vin: string;
+  licensePlate: string | null;
+  make: string | null;
+  model: string | null;
+  year: number | null;
+  type: 'TRACTOR' | 'TRAILER' | 'VAN' | 'CAR' | 'OTHER' | null;
+  capacity: number | null;
+  insuranceProvider: string | null;
+  insurancePolicyNumber: string | null;
+  ownerInfo: string | null;
+  photoUrl: string | null;
+  nextMaintenanceDate: Date | null;
+  nextInspectionDate: Date | null;
+  status: 'ACTIVE' | 'MAINTENANCE' | 'RETIRED';
+  isActive: boolean;
+  currentDriverId: number | null;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/main/tests/vehicles/dashboard.test.tsx
+++ b/main/tests/vehicles/dashboard.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }))
+vi.mock('../../src/lib/fetchers/vehicles')
+import FleetDashboard from '../../src/features/vehicles/components/FleetDashboard'
+import * as fetchers from '../../src/lib/fetchers/vehicles'
+
+describe('FleetDashboard', () => {
+  it('renders metrics', async () => {
+    vi.mocked(fetchers.getFleetOverview).mockResolvedValue({
+      total: 3,
+      active: 2,
+      maintenance: 1,
+      retired: 0,
+      maintenanceDue: 1,
+      inspectionDue: 0,
+    })
+    const el = await FleetDashboard({ orgId: 1 })
+    const html = renderToString(el)
+    expect(html).toContain('Fleet Size')
+    expect(html).toContain('Maintenance Due')
+  })
+})

--- a/main/tests/vehicles/fetchers.test.ts
+++ b/main/tests/vehicles/fetchers.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn(), select: vi.fn(() => ({ where: vi.fn(() => ({ orderBy: vi.fn() })) })) } }))
+import { db } from '../../src/lib/db'
+import * as fetchers from '../../src/lib/fetchers/vehicles'
+
+describe('getFleetOverview', () => {
+  it('returns counts', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 3 }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ status: 'ACTIVE', count: 2 }, { status: 'MAINTENANCE', count: 1 }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 0 }] } as any)
+    const res = await fetchers.getFleetOverview(1)
+    expect(res.total).toBe(3)
+    expect(res.active).toBe(2)
+    expect(res.maintenance).toBe(1)
+    expect(res.retired).toBe(0)
+    expect(res.maintenanceDue).toBe(1)
+  })
+})


### PR DESCRIPTION
Closes #74

## Summary
- add FleetDashboard and VehicleList components for vehicles
- extend vehicle schema with maintenance and inspection dates
- support fleet overview metrics and vehicle listing fetchers
- allow bulk vehicle status updates
- expose dashboard and list on vehicles page
- add Drizzle migration and snapshots
- cover fleet overview logic with unit tests

## Checklist
- [x] Passes CI
- [ ] Updates docs
- [ ] Notifies milestone

------
https://chatgpt.com/codex/tasks/task_e_686343b0bd54832789da6c121ea48144