### PR TITLE
feat: add admin user management

### DIFF
--- a/main/src/app/dashboard/admin/users/[id]/edit/page.tsx
+++ b/main/src/app/dashboard/admin/users/[id]/edit/page.tsx
@@ -1,0 +1,16 @@
+import { getUserById } from '@/lib/fetchers/users'
+import UserForm from '@/features/admin/components/UserForm'
+import { notFound } from 'next/navigation'
+
+interface Props { params: { id: string } }
+
+export default async function EditUserPage({ params }: Props) {
+  const user = await getUserById(Number(params.id))
+  if (!user) notFound()
+  return (
+    <div className="p-8">
+      <UserForm user={user} />
+    </div>
+  )
+}
+

--- a/main/src/app/dashboard/admin/users/page.tsx
+++ b/main/src/app/dashboard/admin/users/page.tsx
@@ -1,13 +1,12 @@
 import InviteUserForm from '@/features/admin/components/InviteUserForm'
 import { requirePermission } from '@/lib/rbac'
-import { db } from '@/lib/db'
-import { users } from '@/lib/schema'
-import { eq } from 'drizzle-orm'
+import { getOrgUsers } from '@/lib/fetchers/users'
+import UserList from '@/features/admin/components/UserList'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
 export default async function AdminUsersPage() {
   const currentUser = await requirePermission('org:admin:manage_users_and_roles')
-  const orgUsers = await db.select().from(users).where(eq(users.orgId, currentUser.orgId))
+  const orgUsers = await getOrgUsers(currentUser.orgId)
 
   return (
     <div className="p-8 space-y-6">
@@ -24,14 +23,7 @@ export default async function AdminUsersPage() {
           <CardTitle>Users</CardTitle>
         </CardHeader>
         <CardContent>
-          <ul className="space-y-2">
-            {orgUsers.map(u => (
-              <li key={u.id} className="flex justify-between">
-                <span>{u.email}</span>
-                <span className="text-muted-foreground">{u.role}</span>
-              </li>
-            ))}
-          </ul>
+          <UserList users={orgUsers} />
         </CardContent>
       </Card>
     </div>

--- a/main/src/features/admin/README.md
+++ b/main/src/features/admin/README.md
@@ -16,6 +16,8 @@ EMAIL_FROM="Road.io <noreply@road.io>"
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 ```
 
-## Page
+## Pages
 
-- `/dashboard/admin/users` – Invite users and view the user list.
+- `/dashboard/admin/users` – Invite users, manage roles and statuses.
+- `/dashboard/admin/users/[id]/edit` – Edit an individual user profile.
+

--- a/main/src/features/admin/components/UserForm.tsx
+++ b/main/src/features/admin/components/UserForm.tsx
@@ -1,0 +1,44 @@
+import { updateUserAction } from '@/lib/actions/users'
+import { SystemRoles } from '@/types/rbac'
+import type { UserProfile } from '@/types/users'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+
+interface Props {
+  user: UserProfile
+}
+
+export default function UserForm({ user }: Props) {
+  return (
+    <form action={updateUserAction} className="space-y-4 max-w-md">
+      <input type="hidden" name="id" value={user.id} />
+      <div className="space-y-2">
+        <Label htmlFor="name">Name</Label>
+        <Input id="name" name="name" defaultValue={user.name ?? ''} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" name="email" type="email" defaultValue={user.email} required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="role">Role</Label>
+        <select id="role" name="role" defaultValue={user.role} className="border rounded h-9 px-3 w-full">
+          {Object.values(SystemRoles).map(r => (
+            <option key={r} value={r}>{r}</option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="status">Status</Label>
+        <select id="status" name="status" defaultValue={user.status} className="border rounded h-9 px-3 w-full">
+          <option value="ACTIVE">Active</option>
+          <option value="INACTIVE">Inactive</option>
+          <option value="SUSPENDED">Suspended</option>
+        </select>
+      </div>
+      <Button type="submit">Save</Button>
+    </form>
+  )
+}
+

--- a/main/src/features/admin/components/UserList.tsx
+++ b/main/src/features/admin/components/UserList.tsx
@@ -1,0 +1,55 @@
+import Link from 'next/link'
+import { bulkUpdateStatusAction } from '@/lib/actions/users'
+import type { UserProfile } from '@/types/users'
+import { Button } from '@/components/ui/button'
+
+interface Props {
+  users: UserProfile[]
+}
+
+export default function UserList({ users }: Props) {
+  return (
+    <form action={async (formData) => {
+      'use server'
+      const ids = formData.getAll('ids').map(id => Number(id))
+      const status = formData.get('status') as 'ACTIVE'|'INACTIVE'|'SUSPENDED'
+      await bulkUpdateStatusAction({ ids, status })
+    }} className="space-y-4">
+      <table className="w-full text-sm border-collapse">
+        <thead>
+          <tr>
+            <th></th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Status</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(u => (
+            <tr key={u.id} className="border-t">
+              <td className="px-2">
+                <input type="checkbox" name="ids" value={u.id} />
+              </td>
+              <td className="px-2">{u.email}</td>
+              <td className="px-2">{u.role}</td>
+              <td className="px-2">{u.status}</td>
+              <td className="px-2">
+                <Link href={`/dashboard/admin/users/${u.id}/edit`} className="text-blue-600 text-sm">Edit</Link>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="flex items-center gap-2">
+        <select name="status" className="border rounded h-9 px-3">
+          <option value="ACTIVE">Active</option>
+          <option value="INACTIVE">Inactive</option>
+          <option value="SUSPENDED">Suspended</option>
+        </select>
+        <Button type="submit">Update Selected</Button>
+      </div>
+    </form>
+  )
+}
+

--- a/main/src/lib/actions/__tests__/users.test.ts
+++ b/main/src/lib/actions/__tests__/users.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { updateUserAction, bulkUpdateStatusAction } from '../users'
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    update: () => ({ set: () => ({ where: () => ({}) }) }),
+  },
+}))
+
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })),
+}))
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { USER_UPDATE: 'user.update' },
+  AUDIT_RESOURCES: { USER: 'user' },
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('updateUserAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('updates user with valid data', async () => {
+    const form = new FormData()
+    form.set('id', '1')
+    form.set('email', 'a@test.com')
+    form.set('role', 'ADMIN')
+    form.set('status', 'ACTIVE')
+    const result = await updateUserAction(form)
+    expect(result.success).toBe(true)
+  })
+
+  it('fails with invalid email', async () => {
+    const form = new FormData()
+    form.set('id', '1')
+    form.set('email', 'bad')
+    form.set('role', 'ADMIN')
+    form.set('status', 'ACTIVE')
+    await expect(updateUserAction(form)).rejects.toThrow()
+  })
+})
+
+describe('bulkUpdateStatusAction', () => {
+  it('updates multiple users', async () => {
+    const result = await bulkUpdateStatusAction({ ids: [1,2], status: 'INACTIVE' })
+    expect(result.success).toBe(true)
+  })
+})
+

--- a/main/src/lib/actions/users.ts
+++ b/main/src/lib/actions/users.ts
@@ -9,12 +9,17 @@ import { revalidatePath } from 'next/cache'
 import { eq, inArray } from 'drizzle-orm'
 import { SystemRoles } from '@/types/rbac'
 
+enum UserStatus {
+  ACTIVE = 'ACTIVE',
+  INACTIVE = 'INACTIVE',
+  SUSPENDED = 'SUSPENDED',
+}
 const updateSchema = z.object({
   id: z.coerce.number(),
   name: z.string().optional(),
   email: z.string().email(),
   role: z.nativeEnum(SystemRoles),
-  status: z.enum(['ACTIVE','INACTIVE','SUSPENDED']),
+  status: z.nativeEnum(UserStatus),
 })
 
 export async function updateUserAction(formData: FormData) {

--- a/main/src/lib/actions/users.ts
+++ b/main/src/lib/actions/users.ts
@@ -1,0 +1,81 @@
+'use server'
+
+import { z } from 'zod'
+import { db } from '@/lib/db'
+import { users } from '@/lib/schema'
+import { requirePermission } from '@/lib/rbac'
+import { createAuditLog, AUDIT_ACTIONS, AUDIT_RESOURCES } from '@/lib/audit'
+import { revalidatePath } from 'next/cache'
+import { eq, inArray } from 'drizzle-orm'
+import { SystemRoles } from '@/types/rbac'
+
+const updateSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  email: z.string().email(),
+  role: z.nativeEnum(SystemRoles),
+  status: z.enum(['ACTIVE','INACTIVE','SUSPENDED']),
+})
+
+export async function updateUserAction(formData: FormData) {
+  const admin = await requirePermission('org:admin:manage_users_and_roles')
+  const input = updateSchema.parse({
+    id: formData.get('id'),
+    name: formData.get('name') || undefined,
+    email: formData.get('email'),
+    role: formData.get('role'),
+    status: formData.get('status'),
+  })
+  const userId = Number(input.id)
+  await db
+    .update(users)
+    .set({
+      name: input.name,
+      email: input.email,
+      role: input.role,
+      status: input.status,
+      isActive: input.status === 'ACTIVE',
+      updatedAt: new Date(),
+    })
+    .where(eq(users.id, userId))
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.USER_UPDATE,
+    resource: AUDIT_RESOURCES.USER,
+    resourceId: input.id,
+    details: { updatedBy: admin.id },
+  })
+
+  revalidatePath('/dashboard/admin/users')
+  revalidatePath(`/dashboard/admin/users/${input.id}/edit`)
+  return { success: true }
+}
+
+const bulkSchema = z.object({
+  ids: z.array(z.coerce.number().int()).min(1),
+  status: z.enum(['ACTIVE','INACTIVE','SUSPENDED']),
+})
+export type BulkStatusInput = z.infer<typeof bulkSchema>
+
+export async function bulkUpdateStatusAction(data: BulkStatusInput) {
+  const admin = await requirePermission('org:admin:manage_users_and_roles')
+  const input = bulkSchema.parse(data)
+  await db
+    .update(users)
+    .set({
+      status: input.status,
+      isActive: input.status === 'ACTIVE',
+      updatedAt: new Date(),
+    })
+    .where(inArray(users.id, input.ids))
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.USER_UPDATE,
+    resource: AUDIT_RESOURCES.USER,
+    details: { updatedBy: admin.id, ids: input.ids, status: input.status },
+  })
+
+  revalidatePath('/dashboard/admin/users')
+  return { success: true }
+}
+

--- a/main/src/lib/actions/users.ts
+++ b/main/src/lib/actions/users.ts
@@ -10,7 +10,7 @@ import { eq, inArray } from 'drizzle-orm'
 import { SystemRoles } from '@/types/rbac'
 
 const updateSchema = z.object({
-  id: z.string(),
+  id: z.coerce.number(),
   name: z.string().optional(),
   email: z.string().email(),
   role: z.nativeEnum(SystemRoles),

--- a/main/src/lib/fetchers/users.ts
+++ b/main/src/lib/fetchers/users.ts
@@ -1,0 +1,36 @@
+import { db } from '@/lib/db'
+import { users } from '@/lib/schema'
+import { eq, inArray } from 'drizzle-orm'
+import type { UserProfile } from '@/types/users'
+
+export async function getOrgUsers(orgId: number): Promise<UserProfile[]> {
+  return db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      role: users.role,
+      status: users.status,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .where(eq(users.orgId, orgId))
+}
+
+export async function getUserById(id: number): Promise<UserProfile | undefined> {
+  const [row] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      role: users.role,
+      status: users.status,
+      createdAt: users.createdAt,
+      updatedAt: users.updatedAt,
+    })
+    .from(users)
+    .where(eq(users.id, id))
+  return row
+}
+

--- a/main/src/lib/rbac.ts
+++ b/main/src/lib/rbac.ts
@@ -15,6 +15,7 @@ export interface AuthenticatedUser {
   role: SystemRoles;
   permissions: string[];
   isActive: boolean;
+  status: typeof import('./schema').userStatusEnum['_']['enumValues'][number];
 }
 
 /**
@@ -38,6 +39,7 @@ export async function getCurrentUser(): Promise<AuthenticatedUser | null> {
         organizationName: organizations.name,
         organizationSlug: organizations.slug,
         role: users.role,
+        status: users.status,
         isActive: users.isActive,
       })
       .from(users)
@@ -68,6 +70,7 @@ export async function getCurrentUser(): Promise<AuthenticatedUser | null> {
       role: user.role as SystemRoles,
       permissions,
       isActive: user.isActive,
+      status: user.status,
     };
   } catch (error) {
     console.error('Error getting current user:', error);

--- a/main/src/lib/schema.ts
+++ b/main/src/lib/schema.ts
@@ -8,6 +8,7 @@ export const subscriptionStatusEnum = pgEnum('subscription_status', ['active', '
 export const loadStatusEnum = pgEnum('load_status', ['pending', 'assigned', 'in_transit', 'delivered', 'cancelled']);
 export const vehicleStatusEnum = pgEnum('vehicle_status', ['ACTIVE', 'MAINTENANCE', 'RETIRED']);
 export const vehicleTypeEnum = pgEnum('vehicle_type', ['TRACTOR', 'TRAILER', 'VAN', 'CAR', 'OTHER']);
+export const userStatusEnum = pgEnum('user_status', ['ACTIVE', 'INACTIVE', 'SUSPENDED']);
 
 // Organizations table (multi-tenant)
 export const organizations = pgTable('organizations', {
@@ -33,6 +34,7 @@ export const users = pgTable('users', {
   name: varchar('name', { length: 255 }),
   orgId: serial('org_id').references(() => organizations.id).notNull(),
   role: systemRoleEnum('role').default('MEMBER').notNull(),
+  status: userStatusEnum('status').default('ACTIVE').notNull(),
   isActive: boolean('is_active').default(true).notNull(),
   lastLoginAt: timestamp('last_login_at'),
   createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/main/src/types/rbac.ts
+++ b/main/src/types/rbac.ts
@@ -30,6 +30,7 @@ export interface UserWithRole {
   orgId: string;
   permissions: string[];
   isActive: boolean;
+  status: 'ACTIVE' | 'INACTIVE' | 'SUSPENDED';
   createdAt: Date;
   updatedAt: Date;
 }

--- a/main/src/types/users.ts
+++ b/main/src/types/users.ts
@@ -1,0 +1,12 @@
+export type UserStatus = 'ACTIVE' | 'INACTIVE' | 'SUSPENDED'
+
+export interface UserProfile {
+  id: number
+  email: string
+  name: string | null
+  role: import('./rbac').SystemRoles
+  status: UserStatus
+  createdAt: Date
+  updatedAt: Date
+}
+


### PR DESCRIPTION
## Summary
- build admin user listing with edit links
- add UserForm and bulk status updates
- implement server actions for updating users
- track user status in schema and types
- remove stray newline file

Closes #18

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: numerous TS errors)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686343632c0c8327848c48edc9fd9cb4