### PR TITLE
feat: add driver availability tracking

### DIFF
--- a/main/drizzle/0004_driver_status.sql
+++ b/main/drizzle/0004_driver_status.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "driver_status" AS ENUM ('AVAILABLE','ON_DUTY','OFF_DUTY');
+ALTER TABLE "drivers" ADD COLUMN "status" driver_status NOT NULL DEFAULT 'AVAILABLE';

--- a/main/src/app/drivers/[id]/page.tsx
+++ b/main/src/app/drivers/[id]/page.tsx
@@ -2,6 +2,8 @@ import { notFound } from 'next/navigation'
 import Link from 'next/link'
 import { getDriverById } from '@/lib/fetchers/drivers'
 import DriverSummary from '@/features/drivers/components/DriverSummary'
+import DriverStatusForm from '@/features/drivers/components/DriverStatusForm'
+import DriverAssignments from '@/features/drivers/components/DriverAssignments'
 import { Button } from '@/components/ui/button'
 
 interface Params { params: { id: string } }
@@ -25,6 +27,10 @@ export default async function DriverDetailPage({ params }: Params) {
         </div>
       </div>
       <DriverSummary driver={driver} />
+      <div className="space-y-4">
+        <DriverStatusForm driverId={driver.id} status={driver.status} />
+        <DriverAssignments driverId={driver.id} />
+      </div>
     </div>
   )
 }

--- a/main/src/features/dispatch/components/AssignmentHistory.tsx
+++ b/main/src/features/dispatch/components/AssignmentHistory.tsx
@@ -4,7 +4,7 @@ export default function AssignmentHistory({ history }: { history: AuditLog[] }) 
   return (
     <div className="space-y-2 text-sm">
       {history.map(entry => {
-        const details = entry.details as Record<string, any> | null
+        const details = entry.details as Record<string, unknown> | null
         return (
           <div key={entry.id} className="border rounded p-2">
             <div className="font-medium">

--- a/main/src/features/dispatch/components/LoadAssignmentForm.tsx
+++ b/main/src/features/dispatch/components/LoadAssignmentForm.tsx
@@ -16,7 +16,10 @@ export default async function LoadAssignmentForm({ loadId, driverId, vehicleId }
   const vehicles = await getAllVehicles(user.orgId)
 
   return (
-    <form action={assignLoad.bind(null, loadId) as any} className="space-y-4">
+    <form
+      action={assignLoad.bind(null, loadId) as unknown as (formData: FormData) => Promise<void>}
+      className="space-y-4"
+    >
       <div className="space-y-2">
         <label htmlFor="driverId" className="block text-sm font-medium">Driver</label>
         <select id="driverId" name="driverId" defaultValue={driverId ?? ''} className="border rounded h-9 px-3 w-full">

--- a/main/src/features/drivers/components/DriverAssignments.tsx
+++ b/main/src/features/drivers/components/DriverAssignments.tsx
@@ -1,0 +1,12 @@
+import { getDriverAssignmentStats } from '@/lib/fetchers/drivers'
+
+export default async function DriverAssignments({ driverId }: { driverId: number }) {
+  const stats = await getDriverAssignmentStats(driverId)
+  return (
+    <div className="space-y-1 text-sm">
+      <p><strong>Current Loads:</strong> {stats.current}</p>
+      <p><strong>Completed Loads:</strong> {stats.completed}</p>
+      <p><strong>Completion Rate:</strong> {Math.round(stats.completionRate * 100)}%</p>
+    </div>
+  )
+}

--- a/main/src/features/drivers/components/DriverStatusForm.tsx
+++ b/main/src/features/drivers/components/DriverStatusForm.tsx
@@ -1,0 +1,29 @@
+import { updateDriverStatus } from '@/lib/actions/drivers'
+
+interface Props {
+  driverId: number
+  status: 'AVAILABLE' | 'ON_DUTY' | 'OFF_DUTY'
+}
+
+export default function DriverStatusForm({ driverId, status }: Props) {
+  return (
+    <form action={updateDriverStatus} className="space-x-2">
+      <input type="hidden" name="id" value={driverId} />
+      <select
+        name="status"
+        defaultValue={status}
+        className="border rounded h-9 px-2"
+      >
+        <option value="AVAILABLE">Available</option>
+        <option value="ON_DUTY">On Duty</option>
+        <option value="OFF_DUTY">Off Duty</option>
+      </select>
+      <button
+        type="submit"
+        className="px-3 py-1 rounded bg-primary text-primary-foreground"
+      >
+        Update
+      </button>
+    </form>
+  )
+}

--- a/main/src/features/drivers/components/DriverSummary.tsx
+++ b/main/src/features/drivers/components/DriverSummary.tsx
@@ -12,7 +12,7 @@ export default function DriverSummary({ driver }: { driver: DriverProfile }) {
         <p><strong>License:</strong> {driver.licenseNumber || 'N/A'}</p>
         <p><strong>License Expiry:</strong> {driver.licenseExpiry ? driver.licenseExpiry.toLocaleDateString() : 'N/A'}</p>
         {driver.dotNumber && <p><strong>DOT:</strong> {driver.dotNumber}</p>}
-        <p><strong>Status:</strong> {driver.isAvailable ? 'Available' : 'Unavailable'}</p>
+        <p><strong>Status:</strong> {driver.status.replace('_', ' ')}</p>
       </CardContent>
     </Card>
   )

--- a/main/src/lib/actions/__tests__/drivers.test.ts
+++ b/main/src/lib/actions/__tests__/drivers.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { updateDriverStatus } from '../drivers'
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({ returning: vi.fn(() => Promise.resolve([{ id: 1, status: 'ON_DUTY' }])) }))
+      }))
+    }))
+  }
+}))
+
+vi.mock('@/lib/rbac', () => ({ requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })) }))
+vi.mock('@/lib/audit', () => ({ createAuditLog: vi.fn(), AUDIT_ACTIONS: { DRIVER_UPDATE: 'driver.update' }, AUDIT_RESOURCES: { DRIVER: 'driver' } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('updateDriverStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('updates driver status', async () => {
+    const form = new FormData()
+    form.set('id', '1')
+    form.set('status', 'ON_DUTY')
+    const result = await updateDriverStatus(form)
+    expect(result.success).toBe(true)
+  })
+
+  it('fails with invalid status', async () => {
+    const form = new FormData()
+    form.set('id', '1')
+    form.set('status', 'BAD')
+    await expect(updateDriverStatus(form)).rejects.toThrow()
+  })
+})

--- a/main/src/lib/fetchers/drivers.ts
+++ b/main/src/lib/fetchers/drivers.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db';
 import { drivers, users } from '@/lib/schema';
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import { DriverProfile } from '@/types/drivers';
 
 export async function getAllDrivers(): Promise<DriverProfile[]> {
@@ -13,6 +13,7 @@ export async function getAllDrivers(): Promise<DriverProfile[]> {
       licenseNumber: drivers.licenseNumber,
       licenseExpiry: drivers.licenseExpiry,
       dotNumber: drivers.dotNumber,
+      status: drivers.status,
       isAvailable: drivers.isAvailable,
       createdAt: drivers.createdAt,
       updatedAt: drivers.updatedAt,
@@ -33,6 +34,7 @@ export async function getDriverById(id: number): Promise<DriverProfile | undefin
       licenseNumber: drivers.licenseNumber,
       licenseExpiry: drivers.licenseExpiry,
       dotNumber: drivers.dotNumber,
+      status: drivers.status,
       isAvailable: drivers.isAvailable,
       createdAt: drivers.createdAt,
       updatedAt: drivers.updatedAt,
@@ -42,4 +44,52 @@ export async function getDriverById(id: number): Promise<DriverProfile | undefin
     .where(eq(drivers.id, id));
 
   return row;
+}
+
+export async function getAvailableDrivers(): Promise<DriverProfile[]> {
+  return db
+    .select({
+      id: drivers.id,
+      userId: drivers.userId,
+      name: users.name,
+      email: users.email,
+      licenseNumber: drivers.licenseNumber,
+      licenseExpiry: drivers.licenseExpiry,
+      dotNumber: drivers.dotNumber,
+      status: drivers.status,
+      isAvailable: drivers.isAvailable,
+      createdAt: drivers.createdAt,
+      updatedAt: drivers.updatedAt,
+    })
+    .from(drivers)
+    .innerJoin(users, eq(drivers.userId, users.id))
+    .where(eq(drivers.status, 'AVAILABLE'));
+}
+
+export interface DriverAssignmentStats {
+  current: number;
+  completed: number;
+  completionRate: number;
+}
+
+export async function getDriverAssignmentStats(
+  driverId: number,
+): Promise<DriverAssignmentStats> {
+  const result = await db.execute<{ current: number; completed: number }>(sql`
+    SELECT
+      count(*) FILTER (WHERE status NOT IN ('delivered','cancelled'))::int AS current,
+      count(*) FILTER (WHERE status = 'delivered')::int AS completed
+    FROM loads
+    WHERE assigned_driver_id = ${driverId}
+  `);
+
+  const current = result.rows[0]?.current ?? 0;
+  const completed = result.rows[0]?.completed ?? 0;
+  const total = current + completed;
+
+  return {
+    current,
+    completed,
+    completionRate: total === 0 ? 0 : Number((completed / total).toFixed(2)),
+  };
 }

--- a/main/src/lib/fetchers/users.ts
+++ b/main/src/lib/fetchers/users.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db'
 import { users } from '@/lib/schema'
-import { eq, inArray } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import type { UserProfile } from '@/types/users'
 
 export async function getOrgUsers(orgId: number): Promise<UserProfile[]> {

--- a/main/src/lib/schema.ts
+++ b/main/src/lib/schema.ts
@@ -37,6 +37,11 @@ export const vehicleStatusEnum = pgEnum("vehicle_status", [
   "MAINTENANCE",
   "RETIRED",
 ]);
+export const driverStatusEnum = pgEnum("driver_status", [
+  "AVAILABLE",
+  "ON_DUTY",
+  "OFF_DUTY",
+]);
 export const vehicleTypeEnum = pgEnum("vehicle_type", [
   "TRACTOR",
   "TRAILER",
@@ -96,6 +101,7 @@ export const drivers = pgTable("drivers", {
   licenseNumber: varchar("license_number", { length: 50 }),
   licenseExpiry: timestamp("license_expiry"),
   dotNumber: varchar("dot_number", { length: 50 }),
+  status: driverStatusEnum("status").default("AVAILABLE").notNull(),
   isAvailable: boolean("is_available").default(true).notNull(),
   currentLocation: jsonb("current_location"), // { lat, lng, address }
   createdAt: timestamp("created_at").defaultNow().notNull(),

--- a/main/src/types/drivers.ts
+++ b/main/src/types/drivers.ts
@@ -6,6 +6,7 @@ export interface DriverProfile {
   licenseNumber: string | null;
   licenseExpiry: Date | null;
   dotNumber: string | null;
+  status: 'AVAILABLE' | 'ON_DUTY' | 'OFF_DUTY';
   isAvailable: boolean;
   createdAt: Date;
   updatedAt: Date;

--- a/main/src/types/drivers.ts
+++ b/main/src/types/drivers.ts
@@ -7,7 +7,6 @@ export interface DriverProfile {
   licenseExpiry: Date | null;
   dotNumber: string | null;
   status: 'AVAILABLE' | 'ON_DUTY' | 'OFF_DUTY';
-  isAvailable: boolean;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -7,7 +7,7 @@ This page summarizes the main features and user flows in Road.io.
 1. **Sign Up & Onboard:** Register and onboard your company.
 2. **Invite Team Members:** Send email invites to users.
 3. **Add Vehicles:** Populate fleet data.
-4. **Add Drivers:** Register driver profiles and manage licensing.
+4. **Add Drivers:** Register driver profiles, manage licensing, and track availability.
 5. **Create Loads:** Schedule deliveries.
 6. **Track Operations:** Use dashboards and modules.
 7. **Explore Modules:** See [Module Guides](#module-guides).


### PR DESCRIPTION
Closes #51

## Summary
- add `driver_status` enum and status column
- implement driver status actions and fetchers
- show availability and load stats in driver pages
- document driver availability
- add tests for status updates

## Checklist
- [x] Passes CI
- [ ] Updates docs
- [ ] Notifies milestone

------
https://chatgpt.com/codex/tasks/task_e_6864777fad688327ba2298db1d111337