### PR TITLE
feat: add vehicle availability tracking

### DIFF
--- a/main/src/app/dashboard/vehicles/availability/page.tsx
+++ b/main/src/app/dashboard/vehicles/availability/page.tsx
@@ -1,0 +1,13 @@
+import { getCurrentUser } from '@/lib/rbac'
+import VehicleAvailabilityList from '@/features/vehicles/components/VehicleAvailabilityList'
+
+export default async function VehicleAvailabilityPage() {
+  const user = await getCurrentUser()
+  if (!user) return null
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold">Vehicle Availability</h1>
+      <VehicleAvailabilityList orgId={user.orgId} />
+    </div>
+  )
+}

--- a/main/src/app/dashboard/vehicles/page.tsx
+++ b/main/src/app/dashboard/vehicles/page.tsx
@@ -11,9 +11,14 @@ export default async function VehiclesPage() {
     <div className="p-8 space-y-6">
       <div className="flex justify-between">
         <h1 className="text-2xl font-bold">Vehicles</h1>
-        <Link href="/dashboard/vehicles/new">
-          <Button>Add Vehicle</Button>
-        </Link>
+        <div className="space-x-2">
+          <Link href="/dashboard/vehicles/availability">
+            <Button variant="secondary">Availability</Button>
+          </Link>
+          <Link href="/dashboard/vehicles/new">
+            <Button>Add Vehicle</Button>
+          </Link>
+        </div>
       </div>
       <FleetDashboard orgId={user.orgId} />
       <VehicleList orgId={user.orgId} />

--- a/main/src/features/dispatch/components/LoadAssignmentForm.tsx
+++ b/main/src/features/dispatch/components/LoadAssignmentForm.tsx
@@ -16,7 +16,7 @@ export default async function LoadAssignmentForm({ loadId, driverId, vehicleId }
   const vehicles = await getAllVehicles(user.orgId)
 
   return (
-    <form action={assignLoad.bind(null, loadId) as (formData: FormData) => Promise<unknown>} className="space-y-4">
+    <form action={assignLoad.bind(null, loadId) as (formData: FormData) => Promise<void>} className="space-y-4">
       <div className="space-y-2">
         <label htmlFor="driverId" className="block text-sm font-medium">Driver</label>
         <select id="driverId" name="driverId" defaultValue={driverId ?? ''} className="border rounded h-9 px-3 w-full">

--- a/main/src/features/dispatch/components/LoadAssignmentForm.tsx
+++ b/main/src/features/dispatch/components/LoadAssignmentForm.tsx
@@ -16,7 +16,7 @@ export default async function LoadAssignmentForm({ loadId, driverId, vehicleId }
   const vehicles = await getAllVehicles(user.orgId)
 
   return (
-    <form action={assignLoad.bind(null, loadId) as any} className="space-y-4">
+    <form action={assignLoad.bind(null, loadId) as (formData: FormData) => Promise<unknown>} className="space-y-4">
       <div className="space-y-2">
         <label htmlFor="driverId" className="block text-sm font-medium">Driver</label>
         <select id="driverId" name="driverId" defaultValue={driverId ?? ''} className="border rounded h-9 px-3 w-full">

--- a/main/src/features/vehicles/components/VehicleAssignmentHistory.tsx
+++ b/main/src/features/vehicles/components/VehicleAssignmentHistory.tsx
@@ -1,17 +1,15 @@
 import type { AuditLog } from '@/lib/schema'
 
-export default function AssignmentHistory({ history }: { history: AuditLog[] }) {
+export default function VehicleAssignmentHistory({ history }: { history: AuditLog[] }) {
   return (
     <div className="space-y-2 text-sm">
       {history.map(entry => {
         const details = entry.details as Record<string, unknown> | null
         return (
           <div key={entry.id} className="border rounded p-2">
-            <div className="font-medium">
-              {new Date(entry.createdAt).toLocaleString()}
-            </div>
+            <div className="font-medium">{new Date(entry.createdAt).toLocaleString()}</div>
+            <div>Load: {details?.loadId ?? 'N/A'}</div>
             <div>Driver: {details?.driverId ?? 'N/A'}</div>
-            <div>Vehicle: {details?.vehicleId ?? 'N/A'}</div>
           </div>
         )
       })}

--- a/main/src/features/vehicles/components/VehicleAvailabilityList.tsx
+++ b/main/src/features/vehicles/components/VehicleAvailabilityList.tsx
@@ -1,0 +1,35 @@
+import { getVehicleAvailability } from '@/lib/fetchers/vehicles'
+
+interface Props {
+  orgId: number
+}
+
+export default async function VehicleAvailabilityList({ orgId }: Props) {
+  const vehicles = await getVehicleAvailability(orgId)
+  return (
+    <table className="w-full text-sm">
+      <thead className="text-left">
+        <tr>
+          <th>ID</th>
+          <th>Make</th>
+          <th>Model</th>
+          <th>Status</th>
+          <th>Assigned</th>
+          <th>Next Maintenance</th>
+        </tr>
+      </thead>
+      <tbody>
+        {vehicles.map(v => (
+          <tr key={v.id} className="border-t">
+            <td>{v.id}</td>
+            <td>{v.make}</td>
+            <td>{v.model}</td>
+            <td>{v.status}</td>
+            <td>{v.isAssigned ? 'Yes' : 'No'}</td>
+            <td>{v.nextMaintenanceDate ? new Date(v.nextMaintenanceDate).toLocaleDateString() : 'N/A'}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/main/src/features/vehicles/components/VehicleAvailabilityList.tsx
+++ b/main/src/features/vehicles/components/VehicleAvailabilityList.tsx
@@ -26,7 +26,7 @@ export default async function VehicleAvailabilityList({ orgId }: Props) {
             <td>{v.model}</td>
             <td>{v.status}</td>
             <td>{v.isAssigned ? 'Yes' : 'No'}</td>
-            <td>{v.nextMaintenanceDate ? new Date(v.nextMaintenanceDate).toLocaleDateString() : 'N/A'}</td>
+            <td>{v.nextMaintenanceDate ? v.nextMaintenanceDate.toLocaleDateString() : 'N/A'}</td>
           </tr>
         ))}
       </tbody>

--- a/main/src/features/vehicles/components/VehicleAvailabilityList.tsx
+++ b/main/src/features/vehicles/components/VehicleAvailabilityList.tsx
@@ -8,6 +8,7 @@ export default async function VehicleAvailabilityList({ orgId }: Props) {
   const vehicles = await getVehicleAvailability(orgId)
   return (
     <table className="w-full text-sm">
+      <caption className="sr-only">Vehicle Availability List</caption>
       <thead className="text-left">
         <tr>
           <th>ID</th>

--- a/main/src/lib/actions/assignments.ts
+++ b/main/src/lib/actions/assignments.ts
@@ -69,6 +69,13 @@ export async function assignLoad(loadId: number, formData: FormData) {
       .update(vehicles)
       .set({ currentDriverId: (input.driverId ?? null) as number | null, updatedAt: new Date() })
       .where(eq(vehicles.id, input.vehicleId))
+
+    await createAuditLog({
+      action: AUDIT_ACTIONS.VEHICLE_ASSIGN,
+      resource: AUDIT_RESOURCES.VEHICLE,
+      resourceId: input.vehicleId.toString(),
+      details: { loadId, driverId: input.driverId, assignedBy: user.id },
+    })
   }
 
   await createAuditLog({

--- a/main/src/lib/fetchers/users.ts
+++ b/main/src/lib/fetchers/users.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/db'
 import { users } from '@/lib/schema'
-import { eq, inArray } from 'drizzle-orm'
+import { eq } from 'drizzle-orm'
 import type { UserProfile } from '@/types/users'
 
 export async function getOrgUsers(orgId: number): Promise<UserProfile[]> {

--- a/main/src/lib/fetchers/vehicles.ts
+++ b/main/src/lib/fetchers/vehicles.ts
@@ -134,7 +134,7 @@ export async function getVehicleAssignmentHistory(vehicleId: number): Promise<Au
     WHERE resource = ${AUDIT_RESOURCES.VEHICLE}
       AND action = ${AUDIT_ACTIONS.VEHICLE_ASSIGN}
       AND resource_id = ${vehicleId}
-    ORDER BY createdAt DESC
+    ORDER BY created_at DESC
   `)
   return res.rows
 }

--- a/main/tests/vehicles/availability.test.tsx
+++ b/main/tests/vehicles/availability.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }))
+import { db } from '../../src/lib/db'
+import * as fetchers from '../../src/lib/fetchers/vehicles'
+import VehicleAvailabilityList from '../../src/features/vehicles/components/VehicleAvailabilityList'
+import { AUDIT_ACTIONS, AUDIT_RESOURCES } from '../../src/lib/audit'
+
+describe('getVehicleAvailability', () => {
+  it('maps rows', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({
+      rows: [
+        { id: 1, make: 'Ford', model: 'F150', status: 'ACTIVE', is_assigned: false, next_maintenance_date: null },
+      ],
+    } as any)
+    const res = await fetchers.getVehicleAvailability(1)
+    expect(res[0].isAssigned).toBe(false)
+  })
+})
+
+describe('getVehicleAssignmentHistory', () => {
+  it('returns audit logs', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          resource: AUDIT_RESOURCES.VEHICLE,
+          action: AUDIT_ACTIONS.VEHICLE_ASSIGN,
+          resourceId: '1',
+          details: { loadId: 2 },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      ],
+    } as any)
+    const res = await fetchers.getVehicleAssignmentHistory(1)
+    expect(res).toHaveLength(1)
+  })
+})
+
+describe('VehicleAvailabilityList', () => {
+  it('renders table', async () => {
+    vi.spyOn(fetchers, 'getVehicleAvailability').mockResolvedValue([
+      { id: 1, make: 'Ford', model: 'F150', status: 'ACTIVE', isAssigned: false, nextMaintenanceDate: null },
+    ])
+    const el = await VehicleAvailabilityList({ orgId: 1 })
+    const html = renderToString(el)
+    expect(html).toContain('Make')
+  })
+})


### PR DESCRIPTION
Closes #75

## Summary
- add vehicle availability fetcher and history fetcher
- log vehicle assignments in assignLoad
- add availability page and component
- add vehicle assignment history component
- update load assignment form typing
- fix lint warnings
- tests for new fetchers and component

## Checklist
- [x] Passes CI
- [ ] Updates docs
- [ ] Notifies milestone

------
https://chatgpt.com/codex/tasks/task_e_686477b3fba883279c859cf8ea0b8395