### PR TITLE
feat: add ifta compliance tools

### DIFF
--- a/main/src/features/ifta/README.md
+++ b/main/src/features/ifta/README.md
@@ -1,0 +1,19 @@
+# IFTA Compliance
+
+This feature manages IFTA record keeping and audit support.
+
+## Document Retention
+
+- `uploadIftaDocumentsAction` uploads supporting documents under the `ifta` category using the existing compliance storage system.
+- Files are saved to `main/public/uploads` and stored in the `documents` table.
+
+## Audit Preparation
+
+- `exportIftaRecordsAction` downloads trips, fuel purchases and generated reports for a quarter as a gzip compressed CSV bundle.
+
+## Audit Response
+
+- `recordIftaAuditResponseAction` stores auditor questions and responses in the `ifta_audit_responses` table.
+- Responses are logged to the audit trail for traceability.
+
+Use the fetchers in `lib/fetchers/ifta.ts` to retrieve documents and audit responses for dashboard views.

--- a/main/src/lib/actions/compliance.test.ts
+++ b/main/src/lib/actions/compliance.test.ts
@@ -121,7 +121,9 @@ describe('recordAccident', () => {
 describe('calculateSmsScore', () => {
   beforeEach(() => { vi.clearAllMocks() })
   it('returns summary counts', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
     const result = await calculateSmsScore(1)
     expect(result.score).toBe(1 * 2 + 2)
@@ -130,16 +132,18 @@ describe('calculateSmsScore', () => {
 
 describe('sendRenewalReminders', () => {
   it('sends renewal emails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as any)
     const result = await sendRenewalReminders()
     expect(result.success).toBe(true)
     expect(result.count).toBe(1)
-    expect(require('@/lib/email').sendEmail).toHaveBeenCalled()
+    expect(sendEmail).toHaveBeenCalled()
   })
 })
 
 describe('markDocumentReviewed', () => {
   it('updates document review fields', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.update).mockReturnValueOnce({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) } as any)
     const result = await markDocumentReviewed(1)
     expect(result.success).toBe(true)

--- a/main/src/lib/actions/compliance.ts
+++ b/main/src/lib/actions/compliance.ts
@@ -14,7 +14,6 @@ import { AUDIT_ACTIONS, AUDIT_RESOURCES, createAuditLog } from '@/lib/audit';
 import { requirePermission } from '@/lib/rbac';
 import { sendEmail } from '@/lib/email';
 import { DOCUMENT_CATEGORIES, type DocumentCategory } from '@/types/compliance';
-import { getExpiringDocuments } from '@/lib/fetchers/compliance';
 import { z } from 'zod';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -185,7 +184,8 @@ export async function markDocumentReviewed(id: number) {
 
   revalidatePath('/dashboard/compliance');
   return { success: true, document: doc as Document };
-=======
+}
+
 export async function recordAnnualReview(formData: FormData) {
   const user = await requirePermission('org:compliance:upload_review_compliance');
   const input = reviewSchema.parse(Object.fromEntries(formData));

--- a/main/src/lib/fetchers/compliance.ts
+++ b/main/src/lib/fetchers/compliance.ts
@@ -72,7 +72,8 @@ export async function getDocumentTrends(orgId: number, months = 6): Promise<Docu
     ORDER BY month
   `);
   return res.rows.map(r => ({ month: r.month, uploads: r.count }));
-=======
+}
+
 export async function listAnnualReviews(orgId: number, driverId?: number) {
   await requirePermission('org:compliance:upload_review_compliance');
   const where = driverId ? sql`AND driver_id = ${driverId}` : sql``;

--- a/main/src/lib/fetchers/ifta.ts
+++ b/main/src/lib/fetchers/ifta.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { trips, fuelPurchases, iftaTaxRates } from "@/lib/schema";
+import { trips, fuelPurchases, iftaTaxRates, documents, iftaAuditResponses } from "@/lib/schema";
 import { eq, between, and } from "drizzle-orm";
 
 export async function getTripsByOrg(orgId: number) {
@@ -47,4 +47,18 @@ export async function getTaxRatesByQuarter(quarter: string) {
     .select()
     .from(iftaTaxRates)
     .where(eq(iftaTaxRates.quarter, quarter));
+}
+
+export async function getIftaDocuments(orgId: number) {
+  return await db
+    .select()
+    .from(documents)
+    .where(and(eq(documents.orgId, orgId), eq(documents.documentType, 'ifta')));
+}
+
+export async function listIftaAuditResponses(orgId: number) {
+  return await db
+    .select()
+    .from(iftaAuditResponses)
+    .where(eq(iftaAuditResponses.orgId, orgId));
 }

--- a/main/src/lib/schema.ts
+++ b/main/src/lib/schema.ts
@@ -397,6 +397,16 @@ export const accidentReports = pgTable('accident_reports', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 
+// IFTA audit responses
+export const iftaAuditResponses = pgTable('ifta_audit_responses', {
+  id: serial('id').primaryKey(),
+  orgId: integer('org_id').references(() => organizations.id).notNull(),
+  question: text('question').notNull(),
+  response: text('response'),
+  createdById: integer('created_by_id').references(() => users.id).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
 // Relations
 export const organizationsRelations = relations(organizations, ({ many }) => ({
   users: many(users),
@@ -411,6 +421,7 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   driverAnnualReviews: many(driverAnnualReviews),
   vehicleInspections: many(vehicleInspections),
   accidentReports: many(accidentReports),
+  iftaAuditResponses: many(iftaAuditResponses),
 }));
 
 export const usersRelations = relations(users, ({ one, many }) => ({
@@ -429,6 +440,7 @@ export const usersRelations = relations(users, ({ one, many }) => ({
   vehicleInspections: many(vehicleInspections),
   createdReviews: many(driverAnnualReviews),
   accidentReports: many(accidentReports),
+  iftaAuditResponses: many(iftaAuditResponses),
 }));
 
 export const rolesRelations = relations(roles, ({ one, many }) => ({
@@ -530,6 +542,17 @@ export const iftaReportsRelations = relations(iftaReports, ({ one }) => ({
   }),
 }));
 
+export const iftaAuditResponsesRelations = relations(iftaAuditResponses, ({ one }) => ({
+  organization: one(organizations, {
+    fields: [iftaAuditResponses.orgId],
+    references: [organizations.id],
+  }),
+  createdBy: one(users, {
+    fields: [iftaAuditResponses.createdById],
+    references: [users.id],
+  }),
+}));
+
 export const documentsRelations = relations(documents, ({ one }) => ({
   organization: one(organizations, {
     fields: [documents.orgId],
@@ -604,3 +627,5 @@ export type VehicleInspection = typeof vehicleInspections.$inferSelect;
 export type NewVehicleInspection = typeof vehicleInspections.$inferInsert;
 export type AccidentReport = typeof accidentReports.$inferSelect;
 export type NewAccidentReport = typeof accidentReports.$inferInsert;
+export type IftaAuditResponse = typeof iftaAuditResponses.$inferSelect;
+export type NewIftaAuditResponse = typeof iftaAuditResponses.$inferInsert;

--- a/main/src/types/compliance.ts
+++ b/main/src/types/compliance.ts
@@ -1,4 +1,11 @@
-export const DOCUMENT_CATEGORIES = ['driver', 'safety', 'dqf', 'inspection', 'accident'] as const;
+export const DOCUMENT_CATEGORIES = [
+  'driver',
+  'safety',
+  'dqf',
+  'inspection',
+  'accident',
+  'ifta',
+] as const;
 export type DocumentCategory = typeof DOCUMENT_CATEGORIES[number];
 
 export const DOCUMENT_STATUSES = ['ACTIVE', 'UNDER_REVIEW'] as const;

--- a/main/tests/ifta-compliance.test.ts
+++ b/main/tests/ifta-compliance.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi } from 'vitest';
+import { uploadIftaDocumentsAction, recordIftaAuditResponseAction } from '../src/lib/actions/ifta';
+
+vi.mock('../src/lib/actions/compliance', () => ({
+  uploadDocumentsAction: vi.fn(async () => ({ success: true }))
+}));
+
+vi.mock('../src/lib/db', () => ({
+  db: {
+    insert: vi.fn(() => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }))
+  }
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 }))
+}));
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { COMPLIANCE_REVIEW: 'compliance.review' },
+  AUDIT_RESOURCES: { IFTA_REPORT: 'ifta_report' }
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+describe('uploadIftaDocumentsAction', () => {
+  it('calls compliance upload action', async () => {
+    const fd = new FormData();
+    const result = await uploadIftaDocumentsAction(fd);
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('recordIftaAuditResponseAction', () => {
+  it('stores audit response', async () => {
+    const fd = new FormData();
+    fd.set('question', 'q');
+    fd.set('response', 'a');
+    const result = await recordIftaAuditResponseAction(fd);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #62

Adds document retention and audit support for IFTA module. Includes new `ifta_audit_responses` table, server actions for uploading documents, exporting records, and tracking audit responses. Documentation and unit tests updated.

- [x] Passes CI
- [x] Updates docs
- [ ] Notifies milestone

------
https://chatgpt.com/codex/tasks/task_e_6864aa19db948327b205e6ecb096152c