### PR TITLE
feat: add revenue tracking

### DIFF
--- a/main/src/app/analytics/page.tsx
+++ b/main/src/app/analytics/page.tsx
@@ -4,8 +4,8 @@ import FleetUtilization from '@/features/analytics/components/FleetUtilization';
 import OperationalKPIs from '@/features/analytics/components/OperationalKPIs';
 import CostAnalysis from '@/features/analytics/components/CostAnalysis';
 import ProfitMetrics from '@/features/analytics/components/ProfitMetrics';
+import RevenueMetrics from '@/features/analytics/components/RevenueMetrics';
 import LiveFleetDashboard from '@/features/analytics/components/LiveFleetDashboard';
-import ProfitMetrics from '@/features/analytics/components/ProfitMetrics';
 import { redirect } from 'next/navigation';
 
 export default async function AnalyticsPage() {
@@ -20,6 +20,7 @@ export default async function AnalyticsPage() {
         <FleetUtilization orgId={user.orgId} />
         <OperationalKPIs orgId={user.orgId} />
         <CostAnalysis orgId={user.orgId} />
+        <RevenueMetrics orgId={user.orgId} />
         <ProfitMetrics orgId={user.orgId} />
       </div>
     </div>

--- a/main/src/features/analytics/components/RevenueMetrics.tsx
+++ b/main/src/features/analytics/components/RevenueMetrics.tsx
@@ -1,0 +1,67 @@
+import React from 'react'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { fetchLoadRevenue, fetchSeasonalRevenue } from '@/lib/fetchers/analytics'
+
+interface Props {
+  orgId: number
+}
+
+export default async function RevenueMetrics({ orgId }: Props) {
+  const [loads, seasonal] = await Promise.all([
+    fetchLoadRevenue(orgId),
+    fetchSeasonalRevenue(orgId),
+  ])
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Load Revenue</CardTitle>
+          <CardDescription>Revenue by delivered load</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="text-left">Load</th>
+                <th className="text-right">Revenue ($)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loads.map(l => (
+                <tr key={l.id}>
+                  <td>{l.loadNumber}</td>
+                  <td className="text-right">{(l.revenue / 100).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Seasonal Revenue Trends</CardTitle>
+          <CardDescription>Monthly revenue totals</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <table className="w-full text-sm">
+            <thead>
+              <tr>
+                <th className="text-left">Month</th>
+                <th className="text-right">Revenue ($)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {seasonal.map(s => (
+                <tr key={s.period}>
+                  <td>{s.period}</td>
+                  <td className="text-right">{(s.totalRevenue / 100).toFixed(2)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/main/src/lib/actions/compliance.test.ts
+++ b/main/src/lib/actions/compliance.test.ts
@@ -121,7 +121,9 @@ describe('recordAccident', () => {
 describe('calculateSmsScore', () => {
   beforeEach(() => { vi.clearAllMocks() })
   it('returns summary counts', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
     const result = await calculateSmsScore(1)
     expect(result.score).toBe(1 * 2 + 2)
@@ -130,16 +132,18 @@ describe('calculateSmsScore', () => {
 
 describe('sendRenewalReminders', () => {
   it('sends renewal emails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as any)
     const result = await sendRenewalReminders()
     expect(result.success).toBe(true)
     expect(result.count).toBe(1)
-    expect(require('@/lib/email').sendEmail).toHaveBeenCalled()
+    expect(sendEmail).toHaveBeenCalled()
   })
 })
 
 describe('markDocumentReviewed', () => {
   it('updates document review fields', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.update).mockReturnValueOnce({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) } as any)
     const result = await markDocumentReviewed(1)
     expect(result.success).toBe(true)

--- a/main/src/lib/actions/compliance.ts
+++ b/main/src/lib/actions/compliance.ts
@@ -185,7 +185,8 @@ export async function markDocumentReviewed(id: number) {
 
   revalidatePath('/dashboard/compliance');
   return { success: true, document: doc as Document };
-=======
+}
+
 export async function recordAnnualReview(formData: FormData) {
   const user = await requirePermission('org:compliance:upload_review_compliance');
   const input = reviewSchema.parse(Object.fromEntries(formData));

--- a/main/src/lib/fetchers/compliance.ts
+++ b/main/src/lib/fetchers/compliance.ts
@@ -72,7 +72,8 @@ export async function getDocumentTrends(orgId: number, months = 6): Promise<Docu
     ORDER BY month
   `);
   return res.rows.map(r => ({ month: r.month, uploads: r.count }));
-=======
+}
+
 export async function listAnnualReviews(orgId: number, driverId?: number) {
   await requirePermission('org:compliance:upload_review_compliance');
   const where = driverId ? sql`AND driver_id = ${driverId}` : sql``;

--- a/main/tests/analytics/revenue-metrics.test.tsx
+++ b/main/tests/analytics/revenue-metrics.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+vi.mock('../../src/lib/fetchers/analytics')
+import RevenueMetrics from '../../src/features/analytics/components/RevenueMetrics'
+import * as fetchers from '../../src/lib/fetchers/analytics'
+
+describe('RevenueMetrics component', () => {
+  it('renders revenue tables', async () => {
+    vi.mocked(fetchers.fetchLoadRevenue).mockResolvedValue([
+      { id: 1, loadNumber: 'L1', revenue: 1000 },
+    ])
+    vi.mocked(fetchers.fetchSeasonalRevenue).mockResolvedValue([
+      { period: '2024-01', totalRevenue: 1000 },
+    ])
+
+    const element = await RevenueMetrics({ orgId: 1 })
+    const html = renderToString(element)
+    expect(html).toContain('Load Revenue')
+    expect(html).toContain('Seasonal Revenue Trends')
+  })
+})

--- a/main/tests/analytics/revenue.fetchers.test.ts
+++ b/main/tests/analytics/revenue.fetchers.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }))
+vi.mock('../../src/lib/rbac', () => ({ requirePermission: vi.fn() }))
+import { db } from '../../src/lib/db'
+import { fetchLoadRevenue, fetchSeasonalRevenue } from '../../src/lib/fetchers/analytics'
+
+describe('fetchLoadRevenue', () => {
+  it('returns revenue per load', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 1, load_number: 'L1', revenue: 1000 }] } as any)
+    const res = await fetchLoadRevenue(1)
+    expect(res[0].revenue).toBe(1000)
+  })
+})
+
+describe('fetchSeasonalRevenue', () => {
+  it('groups revenue by month', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ period: '2024-01', total: 5000 }] } as any)
+    const res = await fetchSeasonalRevenue(1)
+    expect(res[0].totalRevenue).toBe(5000)
+  })
+})


### PR DESCRIPTION
## Summary
- add LoadRevenue and SeasonalRevenue fetchers
- display revenue metrics in analytics dashboard
- include revenue metric component
- fix merge markers in compliance modules
- adjust tests and add revenue unit tests

## Checklist
- [ ] Passes CI
- [ ] Updates docs
- [ ] Notifies milestone


------
https://chatgpt.com/codex/tasks/task_e_6864a9e775d08327a385df5734594906