### PR TITLE
feat: add safety analytics

### DIFF
--- a/main/src/app/analytics/page.tsx
+++ b/main/src/app/analytics/page.tsx
@@ -3,9 +3,9 @@ import { getCurrentUser } from '@/lib/rbac';
 import FleetUtilization from '@/features/analytics/components/FleetUtilization';
 import OperationalKPIs from '@/features/analytics/components/OperationalKPIs';
 import CostAnalysis from '@/features/analytics/components/CostAnalysis';
-import ProfitMetrics from '@/features/analytics/components/ProfitMetrics';
 import LiveFleetDashboard from '@/features/analytics/components/LiveFleetDashboard';
 import ProfitMetrics from '@/features/analytics/components/ProfitMetrics';
+import SafetyMetrics from '@/features/analytics/components/SafetyMetrics';
 import { redirect } from 'next/navigation';
 
 export default async function AnalyticsPage() {
@@ -21,6 +21,7 @@ export default async function AnalyticsPage() {
         <OperationalKPIs orgId={user.orgId} />
         <CostAnalysis orgId={user.orgId} />
         <ProfitMetrics orgId={user.orgId} />
+        <SafetyMetrics orgId={user.orgId} />
       </div>
     </div>
   );

--- a/main/src/features/analytics/components/SafetyMetrics.tsx
+++ b/main/src/features/analytics/components/SafetyMetrics.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card'
+import { fetchAccidentRate, fetchSafetyIncidents } from '@/lib/fetchers/analytics'
+
+interface Props {
+  orgId: number
+}
+
+export default async function SafetyMetrics({ orgId }: Props) {
+  const [rate, incidents] = await Promise.all([
+    fetchAccidentRate(orgId),
+    fetchSafetyIncidents(orgId),
+  ])
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Accident Rate</CardTitle>
+          <CardDescription>Accidents per million miles</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <div className="flex justify-between text-sm">
+            <span>Total Accidents</span>
+            <span>{rate.accidents}</span>
+          </div>
+          <div className="flex justify-between text-sm">
+            <span>Total Miles</span>
+            <span>{rate.totalMiles}</span>
+          </div>
+          <div className="flex justify-between font-medium">
+            <span>Accidents / 1M Miles</span>
+            <span>{rate.accidentsPerMillionMiles.toFixed(2)}</span>
+          </div>
+        </CardContent>
+      </Card>
+      <Card>
+        <CardHeader>
+          <CardTitle>Recent Incidents</CardTitle>
+          <CardDescription>Last 5 accident reports</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          {incidents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No incidents reported</p>
+          ) : (
+            <ul className="space-y-1 text-sm">
+              {incidents.map((i) => (
+                <li key={i.id}>
+                  {new Date(i.occurredAt).toLocaleDateString()} - {i.description ?? 'No details'}
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+

--- a/main/src/lib/actions/__tests__/compliance.test.ts
+++ b/main/src/lib/actions/__tests__/compliance.test.ts
@@ -121,8 +121,8 @@ describe('recordAccident', () => {
 describe('calculateSmsScore', () => {
   beforeEach(() => { vi.clearAllMocks() })
   it('returns summary counts', async () => {
-    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as any)
-    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as unknown as { rows: { count: number }[] })
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as unknown as { rows: { count: number }[] })
     const result = await calculateSmsScore(1)
     expect(result.score).toBe(1 * 2 + 2)
   })
@@ -130,17 +130,21 @@ describe('calculateSmsScore', () => {
 
 describe('sendRenewalReminders', () => {
   it('sends renewal emails', async () => {
-    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as unknown as { rows: { id: number; fileName: string; email: string; expiresAt: Date }[] })
     const result = await sendRenewalReminders()
     expect(result.success).toBe(true)
     expect(result.count).toBe(1)
-    expect(require('@/lib/email').sendEmail).toHaveBeenCalled()
+    expect(sendEmail).toHaveBeenCalled()
   })
 })
 
 describe('markDocumentReviewed', () => {
   it('updates document review fields', async () => {
-    vi.mocked(db.update).mockReturnValueOnce({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) } as any)
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: () => ({
+        where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) })
+      })
+    } as unknown as { set: () => { where: () => { returning: () => Promise<{ id: number }[]> } } })
     const result = await markDocumentReviewed(1)
     expect(result.success).toBe(true)
   })

--- a/main/src/lib/actions/compliance.ts
+++ b/main/src/lib/actions/compliance.ts
@@ -185,7 +185,7 @@ export async function markDocumentReviewed(id: number) {
 
   revalidatePath('/dashboard/compliance');
   return { success: true, document: doc as Document };
-=======
+}
 export async function recordAnnualReview(formData: FormData) {
   const user = await requirePermission('org:compliance:upload_review_compliance');
   const input = reviewSchema.parse(Object.fromEntries(formData));

--- a/main/src/lib/fetchers/compliance.ts
+++ b/main/src/lib/fetchers/compliance.ts
@@ -72,7 +72,7 @@ export async function getDocumentTrends(orgId: number, months = 6): Promise<Docu
     ORDER BY month
   `);
   return res.rows.map(r => ({ month: r.month, uploads: r.count }));
-=======
+}
 export async function listAnnualReviews(orgId: number, driverId?: number) {
   await requirePermission('org:compliance:upload_review_compliance');
   const where = driverId ? sql`AND driver_id = ${driverId}` : sql``;

--- a/main/tests/analytics/safety-metrics.test.tsx
+++ b/main/tests/analytics/safety-metrics.test.tsx
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from 'vitest'
+import React from 'react'
+import { renderToString } from 'react-dom/server'
+vi.mock('../../src/lib/fetchers/analytics')
+
+import SafetyMetrics from '../../src/features/analytics/components/SafetyMetrics'
+import * as fetchers from '../../src/lib/fetchers/analytics'
+
+describe('SafetyMetrics component', () => {
+  it('renders accident rate and incidents', async () => {
+    vi.mocked(fetchers.fetchAccidentRate).mockResolvedValue({
+      totalMiles: 1000,
+      accidents: 2,
+      accidentsPerMillionMiles: 2000,
+    })
+    vi.mocked(fetchers.fetchSafetyIncidents).mockResolvedValue([
+      { id: 1, occurredAt: new Date('2024-01-01'), description: 'Test', injuries: false, fatalities: false },
+    ])
+
+    const element = await SafetyMetrics({ orgId: 1 })
+    const html = renderToString(element)
+    expect(html).toContain('Accident Rate')
+    expect(html).toContain('Recent Incidents')
+  })
+})
+

--- a/main/tests/analytics/safety.fetchers.test.ts
+++ b/main/tests/analytics/safety.fetchers.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }))
+vi.mock('../../src/lib/rbac', () => ({ requirePermission: vi.fn() }))
+
+import { db } from '../../src/lib/db'
+import { fetchAccidentRate, fetchSafetyIncidents } from '../../src/lib/fetchers/analytics'
+
+describe('fetchAccidentRate', () => {
+  it('calculates accidents per million miles', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ sum: 1000 }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
+    const res = await fetchAccidentRate(1)
+    expect(res.accidentsPerMillionMiles).toBeCloseTo(2000, 2)
+  })
+})
+
+describe('fetchSafetyIncidents', () => {
+  it('returns list of incidents', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({
+      rows: [
+        {
+          id: 1,
+          occurred_at: new Date('2024-01-01'),
+          description: 'Test',
+          injuries: false,
+          fatalities: false,
+        },
+      ],
+    } as any)
+    const res = await fetchSafetyIncidents(1)
+    expect(res[0].description).toBe('Test')
+  })
+})
+


### PR DESCRIPTION
Closes #31

Adds accident rate and incident reporting to the analytics module.
- New fetchers for accident rate and safety incidents
- SafetyMetrics dashboard component
- Dashboard updated to display safety metrics
- Unit and integration tests
- Fixed lint issues and moved compliance test

Checklist:
- [x] Passes `npm run lint`
- [ ] Passes `npm run typecheck`
- [ ] Passes `npm run test -- analytics`


------
https://chatgpt.com/codex/tasks/task_e_6864a9d32e848327b4dbd5271c4d339f