### PR TITLE
feat: add admin dashboard

### DIFF
--- a/main/src/app/dashboard/admin/layout.tsx
+++ b/main/src/app/dashboard/admin/layout.tsx
@@ -1,0 +1,12 @@
+import AdminNav from '@/features/admin/components/AdminNav'
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen md:flex">
+      <aside className="hidden md:block w-48 border-r p-4">
+        <AdminNav />
+      </aside>
+      <div className="flex-1">{children}</div>
+    </div>
+  )
+}

--- a/main/src/app/dashboard/admin/page.tsx
+++ b/main/src/app/dashboard/admin/page.tsx
@@ -1,0 +1,19 @@
+import { requireRole } from '@/lib/rbac'
+import { SystemRoles } from '@/types/rbac'
+import OverviewCards from '@/features/admin/components/OverviewCards'
+import SystemMetricsPanel from '@/features/admin/components/SystemMetricsPanel'
+import RecentActivity from '@/features/admin/components/RecentActivity'
+
+export default async function AdminDashboardPage() {
+  await requireRole(SystemRoles.ADMIN)
+  return (
+    <div className="p-8 space-y-6">
+      <h1 className="text-2xl font-bold">Admin Dashboard</h1>
+      <OverviewCards />
+      <div className="grid gap-6 md:grid-cols-2">
+        <SystemMetricsPanel />
+        <RecentActivity />
+      </div>
+    </div>
+  )
+}

--- a/main/src/app/dashboard/admin/users/page.tsx
+++ b/main/src/app/dashboard/admin/users/page.tsx
@@ -1,12 +1,18 @@
 import InviteUserForm from '@/features/admin/components/InviteUserForm'
 import { requirePermission } from '@/lib/rbac'
-import { getOrgUsers } from '@/lib/fetchers/users'
+import { getUserList } from '@/lib/fetchers/users'
 import UserList from '@/features/admin/components/UserList'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 
-export default async function AdminUsersPage() {
+interface Props {
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+
+export default async function AdminUsersPage({ searchParams }: Props) {
   const currentUser = await requirePermission('org:admin:manage_users_and_roles')
-  const orgUsers = await getOrgUsers(currentUser.orgId)
+  const sort = (searchParams.sort as 'name'|'email'|'role'|'createdAt') || 'createdAt'
+  const status = searchParams.status as 'ACTIVE' | 'INACTIVE' | undefined
+  const orgUsers = await getUserList(currentUser.orgId, sort, status)
 
   return (
     <div className="p-8 space-y-6">
@@ -22,7 +28,27 @@ export default async function AdminUsersPage() {
         <CardHeader>
           <CardTitle>Users</CardTitle>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-4">
+          <form method="get" className="flex items-end gap-2">
+            <div>
+              <label className="text-sm" htmlFor="status">Status</label>
+              <select id="status" name="status" defaultValue={status ?? ''} className="border rounded h-8 px-2 ml-2">
+                <option value="">All</option>
+                <option value="ACTIVE">Active</option>
+                <option value="INACTIVE">Inactive</option>
+              </select>
+            </div>
+            <div>
+              <label className="text-sm" htmlFor="sort">Sort</label>
+              <select id="sort" name="sort" defaultValue={sort} className="border rounded h-8 px-2 ml-2">
+                <option value="createdAt">Created</option>
+                <option value="name">Name</option>
+                <option value="email">Email</option>
+                <option value="role">Role</option>
+              </select>
+            </div>
+            <button type="submit" className="h-8 px-3 rounded bg-primary text-primary-foreground">Apply</button>
+          </form>
           <UserList users={orgUsers} />
         </CardContent>
       </Card>

--- a/main/src/features/admin/README.md
+++ b/main/src/features/admin/README.md
@@ -23,4 +23,5 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 - `/dashboard/admin/roles` – Manage custom roles and permissions.
 - `/dashboard/admin/company` – Manage company profile and branding.
 - `/dashboard/admin/tenant` – Multi-tenant administration and monitoring.
+- `/dashboard/admin` – Admin dashboard and system metrics overview.
 

--- a/main/src/features/admin/components/AdminNav.tsx
+++ b/main/src/features/admin/components/AdminNav.tsx
@@ -1,0 +1,29 @@
+"use client"
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import clsx from 'clsx'
+
+const links = [
+  { href: '/dashboard/admin', label: 'Overview' },
+  { href: '/dashboard/admin/users', label: 'Users' },
+  { href: '/dashboard/admin/roles', label: 'Roles' },
+  { href: '/dashboard/admin/company', label: 'Company' },
+  { href: '/dashboard/admin/tenant', label: 'Tenant' },
+]
+
+export default function AdminNav() {
+  const pathname = usePathname()
+  return (
+    <nav className="flex flex-col gap-2">
+      {links.map(l => (
+        <Link
+          key={l.href}
+          href={l.href}
+          className={clsx('px-3 py-2 rounded hover:underline', pathname === l.href && 'bg-muted')}
+        >
+          {l.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/main/src/features/admin/components/OverviewCards.tsx
+++ b/main/src/features/admin/components/OverviewCards.tsx
@@ -1,0 +1,28 @@
+import { getOrganizationStatsAction } from '@/lib/actions/admin'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+export default async function OverviewCards() {
+  const { stats } = await getOrganizationStatsAction()
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader><CardTitle>Total Users</CardTitle></CardHeader>
+        <CardContent className="text-2xl font-bold">{stats.totalUsers}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle>Active Users</CardTitle></CardHeader>
+        <CardContent className="text-2xl font-bold">{stats.activeUsers}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle>Max Users</CardTitle></CardHeader>
+        <CardContent className="text-2xl font-bold">{stats.maxUsers}</CardContent>
+      </Card>
+      <Card>
+        <CardHeader><CardTitle>Subscription</CardTitle></CardHeader>
+        <CardContent className="text-sm">
+          {stats.subscriptionPlan} / {stats.subscriptionStatus}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/main/src/features/admin/components/RecentActivity.tsx
+++ b/main/src/features/admin/components/RecentActivity.tsx
@@ -1,0 +1,21 @@
+import { getRecentAuditLogsAction } from '@/lib/actions/admin'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+export default async function RecentActivity() {
+  const logs = await getRecentAuditLogsAction({ limit: 5 })
+  return (
+    <Card>
+      <CardHeader><CardTitle>Recent Activity</CardTitle></CardHeader>
+      <CardContent className="text-sm">
+        <ul className="space-y-1">
+          {logs.map(l => (
+            <li key={l.id} className="flex justify-between">
+              <span>{l.action}</span>
+              <span>{new Date(l.createdAt).toLocaleString()}</span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/features/admin/components/SystemMetricsPanel.tsx
+++ b/main/src/features/admin/components/SystemMetricsPanel.tsx
@@ -1,0 +1,17 @@
+import { getSystemMetricsAction } from '@/lib/actions/admin'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+
+export default async function SystemMetricsPanel() {
+  const metrics = await getSystemMetricsAction()
+  return (
+    <Card>
+      <CardHeader><CardTitle>System Metrics</CardTitle></CardHeader>
+      <CardContent className="space-y-2 text-sm">
+        <div className="flex justify-between"><span>Uptime</span><span>{Math.round(metrics.uptime/60)}m</span></div>
+        <div className="flex justify-between"><span>Load Avg</span><span>{metrics.load.toFixed(2)}</span></div>
+        <div className="flex justify-between"><span>Free Memory</span><span>{(metrics.freeMem/1024/1024).toFixed(0)} MB</span></div>
+        <div className="flex justify-between"><span>DB Connections</span><span>{metrics.dbConnections}</span></div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/features/admin/components/SystemMetricsPanel.tsx
+++ b/main/src/features/admin/components/SystemMetricsPanel.tsx
@@ -9,7 +9,10 @@ export default async function SystemMetricsPanel() {
       <CardContent className="space-y-2 text-sm">
         <div className="flex justify-between"><span>Uptime</span><span>{Math.round(metrics.uptime/60)}m</span></div>
         <div className="flex justify-between"><span>Load Avg</span><span>{metrics.load.toFixed(2)}</span></div>
-        <div className="flex justify-between"><span>Free Memory</span><span>{(metrics.freeMem/1024/1024).toFixed(0)} MB</span></div>
+        <div className="flex justify-between">
+          <span>Memory</span>
+          <span>{(metrics.freeMem / 1024 / 1024).toFixed(0)} MB / {(metrics.totalMem / 1024 / 1024).toFixed(0)} MB</span>
+        </div>
         <div className="flex justify-between"><span>DB Connections</span><span>{metrics.dbConnections}</span></div>
       </CardContent>
     </Card>

--- a/main/src/lib/actions/admin.ts
+++ b/main/src/lib/actions/admin.ts
@@ -10,7 +10,11 @@ import { requirePermission, requireRole } from "../rbac";
 import { SystemRoles } from "@/types/rbac";
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_RESOURCES } from "../audit";
 import { eq, and, desc, count } from "drizzle-orm";
-import { checkTenantIsolation } from "../fetchers/admin";
+import {
+  checkTenantIsolation,
+  fetchSystemMetrics,
+  fetchRecentAuditLogs,
+} from "../fetchers/admin";
 
 // Validation schemas
 const inviteSchema = z.object({
@@ -379,6 +383,16 @@ export async function getOrganizationStatsAction() {
     console.error("Error fetching organization stats:", error);
     return { success: false, error: "Failed to fetch organization stats" };
   }
+}
+
+export async function getSystemMetricsAction() {
+  await requireRole(SystemRoles.ADMIN);
+  return fetchSystemMetrics();
+}
+
+export async function getRecentAuditLogsAction({ limit = 5 }: { limit?: number }) {
+  const admin = await requireRole(SystemRoles.ADMIN);
+  return fetchRecentAuditLogs(admin.orgId, limit);
 }
 
 export async function sendWelcomeEmailAction(

--- a/main/src/lib/actions/compliance.test.ts
+++ b/main/src/lib/actions/compliance.test.ts
@@ -121,7 +121,9 @@ describe('recordAccident', () => {
 describe('calculateSmsScore', () => {
   beforeEach(() => { vi.clearAllMocks() })
   it('returns summary counts', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as any)
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
     const result = await calculateSmsScore(1)
     expect(result.score).toBe(1 * 2 + 2)
@@ -130,16 +132,18 @@ describe('calculateSmsScore', () => {
 
 describe('sendRenewalReminders', () => {
   it('sends renewal emails', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as any)
     const result = await sendRenewalReminders()
     expect(result.success).toBe(true)
     expect(result.count).toBe(1)
-    expect(require('@/lib/email').sendEmail).toHaveBeenCalled()
+    expect(sendEmail).toHaveBeenCalled()
   })
 })
 
 describe('markDocumentReviewed', () => {
   it('updates document review fields', async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     vi.mocked(db.update).mockReturnValueOnce({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) } as any)
     const result = await markDocumentReviewed(1)
     expect(result.success).toBe(true)

--- a/main/src/lib/actions/compliance.ts
+++ b/main/src/lib/actions/compliance.ts
@@ -185,7 +185,8 @@ export async function markDocumentReviewed(id: number) {
 
   revalidatePath('/dashboard/compliance');
   return { success: true, document: doc as Document };
-=======
+}
+
 export async function recordAnnualReview(formData: FormData) {
   const user = await requirePermission('org:compliance:upload_review_compliance');
   const input = reviewSchema.parse(Object.fromEntries(formData));

--- a/main/src/lib/fetchers/compliance.ts
+++ b/main/src/lib/fetchers/compliance.ts
@@ -72,7 +72,8 @@ export async function getDocumentTrends(orgId: number, months = 6): Promise<Docu
     ORDER BY month
   `);
   return res.rows.map(r => ({ month: r.month, uploads: r.count }));
-=======
+}
+
 export async function listAnnualReviews(orgId: number, driverId?: number) {
   await requirePermission('org:compliance:upload_review_compliance');
   const where = driverId ? sql`AND driver_id = ${driverId}` : sql``;

--- a/main/tests/admin/dashboard.test.ts
+++ b/main/tests/admin/dashboard.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest'
+vi.mock('../../src/lib/db', () => ({ db: { execute: vi.fn() } }))
+vi.mock('os', () => ({
+  uptime: vi.fn(() => 100),
+  loadavg: vi.fn(() => [0.5]),
+  totalmem: vi.fn(() => 1000),
+  freemem: vi.fn(() => 200),
+}))
+import { db } from '../../src/lib/db'
+import { fetchSystemMetrics, fetchRecentAuditLogs } from '../../src/lib/fetchers/admin'
+
+describe('fetchSystemMetrics', () => {
+  it('returns system stats', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
+    const res = await fetchSystemMetrics()
+    expect(res.uptime).toBe(100)
+    expect(res.dbConnections).toBe(2)
+  })
+})
+
+describe('fetchRecentAuditLogs', () => {
+  it('returns recent logs', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 1, action: 'a', resource: 'r', userId: 1, createdAt: new Date() }] } as any)
+    const res = await fetchRecentAuditLogs(1, 1)
+    expect(res.length).toBe(1)
+    expect(res[0].action).toBe('a')
+  })
+})


### PR DESCRIPTION
Closes #24

## Summary
- build admin dashboard page with overview cards and metrics
- add admin navigation and layout
- implement system metrics fetcher and recent activity panel
- extend user list with sorting and filtering
- update admin README and add unit tests

## Testing
- `npm run lint`
- `npm run typecheck` *(fails: several type errors)*
- `npm run test` *(fails: database env and missing constants)*

------
https://chatgpt.com/codex/tasks/task_e_6864a9b2a7fc8327883d6bdc38bac303