### PR TITLE
feat: add integration management

### DIFF
--- a/main/src/app/dashboard/settings/integrations/page.tsx
+++ b/main/src/app/dashboard/settings/integrations/page.tsx
@@ -1,0 +1,11 @@
+import { requirePermission } from '@/lib/rbac'
+import IntegrationConfigForm from '@/features/settings/IntegrationConfigForm'
+
+export default async function IntegrationSettingsPage() {
+  await requirePermission('org:admin:configure_company_settings')
+  return (
+    <div className="p-8 max-w-2xl mx-auto">
+      <IntegrationConfigForm />
+    </div>
+  )
+}

--- a/main/src/app/dashboard/settings/notifications/page.tsx
+++ b/main/src/app/dashboard/settings/notifications/page.tsx
@@ -1,0 +1,11 @@
+import { requirePermission } from '@/lib/rbac'
+import NotificationSettingsForm from '@/features/settings/NotificationSettingsForm'
+
+export default async function NotificationSettingsPage() {
+  await requirePermission('org:admin:configure_company_settings')
+  return (
+    <div className="p-8 max-w-2xl mx-auto">
+      <NotificationSettingsForm />
+    </div>
+  )
+}

--- a/main/src/app/dashboard/settings/page.tsx
+++ b/main/src/app/dashboard/settings/page.tsx
@@ -20,6 +20,12 @@ export default async function SettingsPage() {
         <Link href="/dashboard/settings/roles" className="underline text-sm">
           Manage Roles
         </Link>
+        <Link href="/dashboard/settings/integrations" className="underline text-sm">
+          Integrations
+        </Link>
+        <Link href="/dashboard/settings/notifications" className="underline text-sm">
+          Notifications
+        </Link>
       </div>
     </div>
   );

--- a/main/src/features/settings/IntegrationConfigForm.tsx
+++ b/main/src/features/settings/IntegrationConfigForm.tsx
@@ -1,0 +1,44 @@
+import { getIntegrationSettings } from '@/lib/fetchers/settings'
+import { updateIntegrationSettingsAction } from '@/lib/actions/settings'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+export default async function IntegrationConfigForm() {
+  const integrations = await getIntegrationSettings()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Integration Settings</CardTitle>
+        <CardDescription>Configure third-party services</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={updateIntegrationSettingsAction} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="eldApiKey">ELD API Key</Label>
+            <Input id="eldApiKey" name="eldApiKey" defaultValue={integrations?.eldApiKey ?? ''} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="fuelCardProvider">Fuel Card Provider</Label>
+            <Input id="fuelCardProvider" name="fuelCardProvider" defaultValue={integrations?.fuelCardProvider ?? ''} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="mappingApiKey">Mapping API Key</Label>
+            <Input id="mappingApiKey" name="mappingApiKey" defaultValue={integrations?.mappingApiKey ?? ''} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="commsWebhookUrl">Communication Webhook URL</Label>
+            <Input id="commsWebhookUrl" name="commsWebhookUrl" defaultValue={integrations?.commsWebhookUrl ?? ''} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="paymentProcessorKey">Payment Processor Key</Label>
+            <Input id="paymentProcessorKey" name="paymentProcessorKey" defaultValue={integrations?.paymentProcessorKey ?? ''} />
+          </div>
+          <Button type="submit">Save</Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/features/settings/NotificationSettingsForm.tsx
+++ b/main/src/features/settings/NotificationSettingsForm.tsx
@@ -1,0 +1,49 @@
+import { getNotificationSettings } from '@/lib/fetchers/settings'
+import { updateNotificationSettingsAction } from '@/lib/actions/settings'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+export default async function NotificationSettingsForm() {
+  const settings = await getNotificationSettings()
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Notification Settings</CardTitle>
+        <CardDescription>Manage notification preferences</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={updateNotificationSettingsAction} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="emailEnabled">Enable Email</Label>
+            <select id="emailEnabled" name="emailEnabled" className="border rounded-md h-9 px-3 w-full" defaultValue={settings?.emailEnabled ? 'true' : 'false'}>
+              <option value="false">Off</option>
+              <option value="true">On</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="smsEnabled">Enable SMS</Label>
+            <select id="smsEnabled" name="smsEnabled" className="border rounded-md h-9 px-3 w-full" defaultValue={settings?.smsEnabled ? 'true' : 'false'}>
+              <option value="false">Off</option>
+              <option value="true">On</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="pushEnabled">Enable Push</Label>
+            <select id="pushEnabled" name="pushEnabled" className="border rounded-md h-9 px-3 w-full" defaultValue={settings?.pushEnabled ? 'true' : 'false'}>
+              <option value="false">Off</option>
+              <option value="true">On</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="escalationEmail">Escalation Email</Label>
+            <Input id="escalationEmail" name="escalationEmail" defaultValue={settings?.escalationEmail ?? ''} />
+          </div>
+          <Button type="submit">Save</Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/lib/actions/__tests__/settings.test.ts
+++ b/main/src/lib/actions/__tests__/settings.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { updateIntegrationSettingsAction, updateNotificationSettingsAction } from '../settings'
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: () => ({
+        where: vi.fn(() => Promise.resolve([{ settings: {} }]))
+      })
+    })),
+    update: vi.fn(() => ({
+      set: () => ({ where: () => Promise.resolve() })
+    }))
+  }
+}))
+
+vi.mock('@/lib/rbac', () => ({ requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })) }))
+vi.mock('@/lib/audit', () => ({ createAuditLog: vi.fn(), AUDIT_ACTIONS: { ORG_SETTINGS_UPDATE: 'org.update' }, AUDIT_RESOURCES: { ORGANIZATION: 'org' } }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+
+describe('updateIntegrationSettingsAction', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+  it('updates integration settings', async () => {
+    const form = new FormData()
+    form.set('eldApiKey', 'key')
+    const result = await updateIntegrationSettingsAction(form)
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('updateNotificationSettingsAction', () => {
+  beforeEach(() => { vi.clearAllMocks() })
+  it('updates notification settings', async () => {
+    const form = new FormData()
+    form.set('emailEnabled', 'true')
+    form.set('escalationEmail', 'a@test.com')
+    const res = await updateNotificationSettingsAction(form)
+    expect(res.success).toBe(true)
+  })
+  it('fails with invalid email', async () => {
+    const form = new FormData()
+    form.set('emailEnabled', 'true')
+    form.set('escalationEmail', 'bad')
+    await expect(updateNotificationSettingsAction(form)).rejects.toThrow()
+  })
+})

--- a/main/src/lib/actions/compliance.test.ts
+++ b/main/src/lib/actions/compliance.test.ts
@@ -121,8 +121,8 @@ describe('recordAccident', () => {
 describe('calculateSmsScore', () => {
   beforeEach(() => { vi.clearAllMocks() })
   it('returns summary counts', async () => {
-    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as any)
-    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 1 }] } as unknown as { rows: Array<{ count: number }> })
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as unknown as { rows: Array<{ count: number }> })
     const result = await calculateSmsScore(1)
     expect(result.score).toBe(1 * 2 + 2)
   })
@@ -130,17 +130,17 @@ describe('calculateSmsScore', () => {
 
 describe('sendRenewalReminders', () => {
   it('sends renewal emails', async () => {
-    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as any)
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 2, fileName: 'b.pdf', email: 'b@test.com', expiresAt: new Date() }] } as unknown as { rows: Array<{ id: number; fileName: string; email: string; expiresAt: Date }> })
     const result = await sendRenewalReminders()
     expect(result.success).toBe(true)
     expect(result.count).toBe(1)
-    expect(require('@/lib/email').sendEmail).toHaveBeenCalled()
+    expect(sendEmail).toHaveBeenCalled()
   })
 })
 
 describe('markDocumentReviewed', () => {
   it('updates document review fields', async () => {
-    vi.mocked(db.update).mockReturnValueOnce({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) } as any)
+    vi.mocked(db.update).mockReturnValueOnce({ set: () => ({ where: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }) } as unknown as { set: Function })
     const result = await markDocumentReviewed(1)
     expect(result.success).toBe(true)
   })

--- a/main/src/lib/actions/compliance.ts
+++ b/main/src/lib/actions/compliance.ts
@@ -14,7 +14,6 @@ import { AUDIT_ACTIONS, AUDIT_RESOURCES, createAuditLog } from '@/lib/audit';
 import { requirePermission } from '@/lib/rbac';
 import { sendEmail } from '@/lib/email';
 import { DOCUMENT_CATEGORIES, type DocumentCategory } from '@/types/compliance';
-import { getExpiringDocuments } from '@/lib/fetchers/compliance';
 import { z } from 'zod';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -185,7 +184,8 @@ export async function markDocumentReviewed(id: number) {
 
   revalidatePath('/dashboard/compliance');
   return { success: true, document: doc as Document };
-=======
+}
+
 export async function recordAnnualReview(formData: FormData) {
   const user = await requirePermission('org:compliance:upload_review_compliance');
   const input = reviewSchema.parse(Object.fromEntries(formData));

--- a/main/src/lib/fetchers/compliance.ts
+++ b/main/src/lib/fetchers/compliance.ts
@@ -72,7 +72,8 @@ export async function getDocumentTrends(orgId: number, months = 6): Promise<Docu
     ORDER BY month
   `);
   return res.rows.map(r => ({ month: r.month, uploads: r.count }));
-=======
+}
+
 export async function listAnnualReviews(orgId: number, driverId?: number) {
   await requirePermission('org:compliance:upload_review_compliance');
   const where = driverId ? sql`AND driver_id = ${driverId}` : sql``;

--- a/main/src/lib/fetchers/settings.ts
+++ b/main/src/lib/fetchers/settings.ts
@@ -2,7 +2,13 @@ import { db } from '../db';
 import { organizations, userPreferences } from '../schema';
 import { getCurrentUser } from '../rbac';
 import { eq } from 'drizzle-orm';
-import type { CompanyProfile, UserPreferences, SystemConfig } from '@/types/settings';
+import type {
+  CompanyProfile,
+  UserPreferences,
+  SystemConfig,
+  IntegrationSettings,
+  NotificationSettings,
+} from '@/types/settings';
 
 export async function getCompanyProfile(): Promise<CompanyProfile | null> {
   const user = await getCurrentUser();
@@ -43,4 +49,32 @@ export async function getSystemConfig(): Promise<SystemConfig | null> {
   const settings = org?.settings as Record<string, unknown> | undefined;
   const config = settings?.systemConfig as SystemConfig | undefined;
   return config ?? null;
+}
+
+export async function getIntegrationSettings(): Promise<IntegrationSettings | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, user.orgId));
+
+  const settings = org?.settings as Record<string, unknown> | undefined;
+  const integrations = settings?.integrationSettings as IntegrationSettings | undefined;
+  return integrations ?? null;
+}
+
+export async function getNotificationSettings(): Promise<NotificationSettings | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, user.orgId));
+
+  const settings = org?.settings as Record<string, unknown> | undefined;
+  const notifications = settings?.notificationSettings as NotificationSettings | undefined;
+  return notifications ?? null;
 }

--- a/main/src/types/settings.ts
+++ b/main/src/types/settings.ts
@@ -50,3 +50,18 @@ export interface SystemConfig {
     retentionDays: number;
   };
 }
+
+export interface IntegrationSettings {
+  eldApiKey?: string;
+  fuelCardProvider?: string;
+  mappingApiKey?: string;
+  commsWebhookUrl?: string;
+  paymentProcessorKey?: string;
+}
+
+export interface NotificationSettings {
+  emailEnabled?: boolean;
+  smsEnabled?: boolean;
+  pushEnabled?: boolean;
+  escalationEmail?: string;
+}


### PR DESCRIPTION
Closes #69

Adds integration and notification management capabilities to the Settings module. New forms allow admins to configure third‑party service credentials and notification preferences. Server actions handle validation and persistence via organization settings.

- New types for integrations and notifications
- Fetchers and actions to read/write these settings
- UI forms and dashboard routes
- Unit tests for actions

Checklist:
- [ ] Passes CI
- [ ] Updates docs
- [ ] Notifies milestone

------
https://chatgpt.com/codex/tasks/task_e_6864aa2e58148327b6d1b95b1e0fa585