### PR TITLE
[Documentation] docs: add code structure and style guide (Core) (Closes #100)

### DIFF
--- a/CODE_STRUCTURE.md
+++ b/CODE_STRUCTURE.md
@@ -1,0 +1,45 @@
+# Code Structure & Style Guide
+
+This document provides an overview of the project layout and summarizes the style standards used throughout **Road.io**. These guidelines complement the details in [AGENTS.md](AGENTS.md) and the wiki.
+
+## Directory Overview
+
+All implementation code lives under [`main/src`](main/src):
+
+- **`app/`** – Next.js App Router routes, layouts, and server components.
+- **`components/`** – Reusable UI components without side effects.
+- **`features/`** – Feature modules grouped by domain (`admin`, `dispatch`, `vehicles`, etc.).
+- **`lib/`** – Server actions, fetchers, schemas, and utilities.
+- **`types/`** – Shared TypeScript types and interfaces.
+- **`public/`** – Static assets such as images and fonts.
+- **`config/`** – Project configuration files.
+
+Business logic should be implemented in server actions within `lib/actions` and validated with Zod. API routes are reserved only for authentication, webhooks, or public integrations.
+
+## Style Guidelines
+
+Road.io follows a feature-driven approach with a strict TypeScript configuration. Key rules include:
+
+- Prefer **server-first rendering** using React Server Components.
+- Use client components only when local state or browser APIs are required.
+- Organize code by feature and domain.
+- Validate all input using Zod schemas.
+- Keep modules small and composable.
+- Enable `strict` mode in TypeScript and avoid the use of `any`.
+- Use Tailwind CSS utility classes and design tokens for styling.
+- Document significant changes and update docs alongside code.
+
+Additional standards—such as testing strategy, API route usage, and deployment practices—are outlined in [wiki/Development-Standards.md](wiki/Development-Standards.md).
+
+## Contributing
+
+Before opening a pull request, run the following commands from the `main` directory:
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+```
+
+For more detailed contributor guidelines, see [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
+

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ CREATE TABLE "users" (
 
 Business logic lives in **server actions** under `lib/actions/`. API routes are reserved for authentication, webhooks and public integrations.
 
+For a deeper look at the repository layout and style conventions, see [CODE_STRUCTURE.md](CODE_STRUCTURE.md).
+
 ## Testing
 
 Run these commands from the `main` directory:


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: documentation
Milestone: Core

## Description
Adds a new `CODE_STRUCTURE.md` guide summarizing the repository layout and primary style guidelines. The README now links to this document for further details.

## Related Issue
Closes #100 - Documentation: project structure guide

## Wave Dependencies
- Builds on: existing documentation
- Enables: future contributor onboarding docs
- Cross-domain integration: none

## Domain Impact
- Primary domain: documentation
- Files modified: `CODE_STRUCTURE.md`, `README.md`
- Integration points: README link to guide

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866c6a3dc808327a488695901156030