### PR TITLE
[Drivers] feat: implement license tracking (MVP) (Closes #50)

### DIFF
--- a/main/src/app/drivers/[id]/page.tsx
+++ b/main/src/app/drivers/[id]/page.tsx
@@ -4,6 +4,10 @@ import { getDriverById } from '@/lib/fetchers/drivers'
 import DriverSummary from '@/features/drivers/components/DriverSummary'
 import DriverStatusForm from '@/features/drivers/components/DriverStatusForm'
 import DriverAssignments from '@/features/drivers/components/DriverAssignments'
+import DriverViolationList from '@/features/drivers/components/DriverViolationList'
+import DriverCertificationList from '@/features/drivers/components/DriverCertificationList'
+import ViolationForm from '@/features/drivers/components/ViolationForm'
+import CertificationForm from '@/features/drivers/components/CertificationForm'
 import { Button } from '@/components/ui/button'
 
 interface Params { params: { id: string } }
@@ -30,6 +34,16 @@ export default async function DriverDetailPage({ params }: Params) {
       <div className="space-y-4">
         <DriverStatusForm driverId={driver.id} status={driver.status} />
         <DriverAssignments driverId={driver.id} />
+        <div>
+          <h2 className="font-semibold">Violations</h2>
+          <DriverViolationList driverId={driver.id} />
+          <ViolationForm driverId={driver.id} />
+        </div>
+        <div>
+          <h2 className="font-semibold">Certifications</h2>
+          <DriverCertificationList driverId={driver.id} />
+          <CertificationForm driverId={driver.id} />
+        </div>
       </div>
     </div>
   )

--- a/main/src/features/drivers/TODO.md
+++ b/main/src/features/drivers/TODO.md
@@ -165,7 +165,7 @@ The Driver Management module handles driver profiles, licensing, hours of servic
 - [ ] `DriverDashboard` - Main driver management view
 - [ ] `HOSLogger` - Hours of service logging interface
 - [ ] `PerformanceTracker` - Performance metrics display
-- [ ] `LicenseTracker` - License and certification management
+- [x] `LicenseTracker` - License and certification management
 - [ ] `AvailabilityCalendar` - Driver scheduling interface
 - [ ] `SafetyRecord` - Safety tracking display
 

--- a/main/src/features/drivers/components/CertificationForm.tsx
+++ b/main/src/features/drivers/components/CertificationForm.tsx
@@ -1,0 +1,30 @@
+import { addDriverCertification } from '@/lib/actions/drivers'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+export default function CertificationForm({ driverId }: { driverId: number }) {
+  return (
+    <form
+      action={async (formData) => {
+        formData.set('driverId', String(driverId))
+        await addDriverCertification(formData)
+      }}
+      className="space-y-4"
+    >
+      <div className="space-y-2">
+        <Label htmlFor="type">Type</Label>
+        <Input id="type" name="type" required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="issuedAt">Issued</Label>
+        <Input id="issuedAt" name="issuedAt" type="date" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="expiresAt">Expires</Label>
+        <Input id="expiresAt" name="expiresAt" type="date" />
+      </div>
+      <Button type="submit">Add Certification</Button>
+    </form>
+  )
+}

--- a/main/src/features/drivers/components/DriverCertificationList.tsx
+++ b/main/src/features/drivers/components/DriverCertificationList.tsx
@@ -1,0 +1,16 @@
+import { getDriverCertifications } from '@/lib/fetchers/drivers'
+
+export default async function DriverCertificationList({ driverId }: { driverId: number }) {
+  const certs = await getDriverCertifications(driverId)
+  if (certs.length === 0) return <p>No certifications.</p>
+  return (
+    <ul className="space-y-1 text-sm">
+      {certs.map(c => (
+        <li key={c.id}>
+          {c.type}
+          {c.expiresAt ? ` (expires ${c.expiresAt.toISOString().slice(0,10)})` : ''}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/main/src/features/drivers/components/DriverForm.tsx
+++ b/main/src/features/drivers/components/DriverForm.tsx
@@ -43,6 +43,23 @@ export default function DriverForm({ driver }: DriverFormProps) {
         />
       </div>
       <div className="space-y-2">
+        <Label htmlFor="licenseClass">License Class</Label>
+        <Input
+          id="licenseClass"
+          name="licenseClass"
+          defaultValue={driver?.licenseClass ?? ''}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="endorsements">Endorsements</Label>
+        <Input
+          id="endorsements"
+          name="endorsements"
+          defaultValue={driver?.endorsements ?? ''}
+        />
+      </div>
+      <div className="space-y-2">
         <Label htmlFor="licenseExpiry">License Expiry</Label>
         <Input
           id="licenseExpiry"

--- a/main/src/features/drivers/components/DriverSummary.tsx
+++ b/main/src/features/drivers/components/DriverSummary.tsx
@@ -10,6 +10,10 @@ export default function DriverSummary({ driver }: { driver: DriverProfile }) {
       </CardHeader>
       <CardContent className="space-y-2 text-sm">
         <p><strong>License:</strong> {driver.licenseNumber || 'N/A'}</p>
+        <p><strong>Class:</strong> {driver.licenseClass || 'N/A'}</p>
+        {driver.endorsements && (
+          <p><strong>Endorsements:</strong> {driver.endorsements}</p>
+        )}
         <p><strong>License Expiry:</strong> {driver.licenseExpiry ? driver.licenseExpiry.toLocaleDateString() : 'N/A'}</p>
         {driver.dotNumber && <p><strong>DOT:</strong> {driver.dotNumber}</p>}
         <p><strong>Status:</strong> {driver.status.replace('_', ' ')}</p>

--- a/main/src/features/drivers/components/DriverViolationList.tsx
+++ b/main/src/features/drivers/components/DriverViolationList.tsx
@@ -1,0 +1,16 @@
+import { getDriverViolations } from '@/lib/fetchers/drivers'
+
+export default async function DriverViolationList({ driverId }: { driverId: number }) {
+  const records = await getDriverViolations(driverId)
+  if (records.length === 0) return <p>No violations.</p>
+  return (
+    <ul className="space-y-1 text-sm">
+      {records.map(v => (
+        <li key={v.id}>
+          {v.type} - {v.occurredAt.toISOString().slice(0,10)}
+          {v.description ? ` (${v.description})` : ''}
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/main/src/features/drivers/components/ViolationForm.tsx
+++ b/main/src/features/drivers/components/ViolationForm.tsx
@@ -1,0 +1,30 @@
+import { recordDriverViolation } from '@/lib/actions/drivers'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+export default function ViolationForm({ driverId }: { driverId: number }) {
+  return (
+    <form
+      action={async (formData) => {
+        formData.set('driverId', String(driverId))
+        await recordDriverViolation(formData)
+      }}
+      className="space-y-4"
+    >
+      <div className="space-y-2">
+        <Label htmlFor="type">Type</Label>
+        <Input id="type" name="type" required />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="occurredAt">Date</Label>
+        <Input id="occurredAt" name="occurredAt" type="date" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="description">Description</Label>
+        <Input id="description" name="description" />
+      </div>
+      <Button type="submit">Record Violation</Button>
+    </form>
+  )
+}

--- a/main/src/features/drivers/types.ts
+++ b/main/src/features/drivers/types.ts
@@ -4,6 +4,8 @@ export interface DriverProfile {
   name: string | null;
   email: string;
   licenseNumber: string | null;
+  licenseClass: string | null;
+  endorsements: string | null;
   licenseExpiry: Date | null;
   dotNumber: string | null;
   status: 'AVAILABLE' | 'ON_DUTY' | 'OFF_DUTY';

--- a/main/src/lib/actions/__tests__/driverLicense.test.ts
+++ b/main/src/lib/actions/__tests__/driverLicense.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import { violationSchema, certificationSchema } from '../drivers'
+
+describe('violationSchema', () => {
+  it('accepts valid data', () => {
+    expect(() =>
+      violationSchema.parse({ driverId: 1, type: 'Speeding' })
+    ).not.toThrow()
+  })
+
+  it('rejects missing type', () => {
+    expect(() => violationSchema.parse({ driverId: 1 })).toThrow()
+  })
+})
+
+describe('certificationSchema', () => {
+  it('accepts valid data', () => {
+    expect(() =>
+      certificationSchema.parse({ driverId: 1, type: 'DOT_MEDICAL' })
+    ).not.toThrow()
+  })
+
+  it('rejects missing type', () => {
+    expect(() => certificationSchema.parse({ driverId: 1 })).toThrow()
+  })
+})

--- a/main/src/lib/actions/drivers.ts
+++ b/main/src/lib/actions/drivers.ts
@@ -2,7 +2,12 @@
 
 import { z } from 'zod'
 import { db } from '@/lib/db'
-import { drivers, users } from '@/lib/schema'
+import {
+  drivers,
+  users,
+  driverViolations,
+  driverCertifications,
+} from '@/lib/schema'
 import { revalidatePath } from 'next/cache'
 import { requirePermission } from '@/lib/rbac'
 import { createAuditLog, AUDIT_ACTIONS, AUDIT_RESOURCES } from '@/lib/audit'
@@ -13,6 +18,8 @@ const createDriverSchema = z.object({
   email: z.string().email(),
   name: z.string().min(1),
   licenseNumber: z.string().min(1),
+  licenseClass: z.string().min(1),
+  endorsements: z.string().optional(),
   licenseExpiry: z.string().optional(),
   dotNumber: z.string().optional()
 })
@@ -24,6 +31,8 @@ export async function createDriver(formData: FormData) {
     email: formData.get('email'),
     name: formData.get('name'),
     licenseNumber: formData.get('licenseNumber'),
+    licenseClass: formData.get('licenseClass'),
+    endorsements: formData.get('endorsements') || undefined,
     licenseExpiry: formData.get('licenseExpiry') || undefined,
     dotNumber: formData.get('dotNumber') || undefined
   })
@@ -41,6 +50,8 @@ export async function createDriver(formData: FormData) {
   const [driver] = await db.insert(drivers).values({
     userId: user.id,
     licenseNumber: input.licenseNumber,
+    licenseClass: input.licenseClass,
+    endorsements: input.endorsements,
     licenseExpiry: input.licenseExpiry ? new Date(input.licenseExpiry) : null,
     dotNumber: input.dotNumber
   }).returning()
@@ -61,6 +72,8 @@ const updateDriverSchema = z.object({
   email: z.string().email(),
   name: z.string().min(1),
   licenseNumber: z.string().min(1),
+  licenseClass: z.string().min(1),
+  endorsements: z.string().optional(),
   licenseExpiry: z.string().optional(),
   dotNumber: z.string().optional()
 })
@@ -73,6 +86,8 @@ export async function updateDriver(formData: FormData) {
     email: formData.get('email'),
     name: formData.get('name'),
     licenseNumber: formData.get('licenseNumber'),
+    licenseClass: formData.get('licenseClass'),
+    endorsements: formData.get('endorsements') || undefined,
     licenseExpiry: formData.get('licenseExpiry') || undefined,
     dotNumber: formData.get('dotNumber') || undefined
   })
@@ -94,6 +109,8 @@ export async function updateDriver(formData: FormData) {
 
   await db.update(drivers).set({
     licenseNumber: input.licenseNumber,
+    licenseClass: input.licenseClass,
+    endorsements: input.endorsements,
     licenseExpiry: input.licenseExpiry ? new Date(input.licenseExpiry) : null,
     dotNumber: input.dotNumber,
     updatedAt: new Date()
@@ -144,5 +161,93 @@ export async function updateDriverStatus(formData: FormData) {
 
   revalidatePath('/drivers')
   revalidatePath(`/drivers/${driverId}`)
+  return { success: true }
+}
+
+// Record a driver violation
+export const violationSchema = z.object({
+  driverId: z.coerce.number(),
+  type: z.string().min(1),
+  description: z.string().optional(),
+  occurredAt: z.string().optional(),
+})
+export type RecordViolationInput = z.infer<typeof violationSchema>
+
+export async function recordDriverViolation(
+  data: FormData | RecordViolationInput,
+) {
+  const values = violationSchema.parse(
+    data instanceof FormData
+      ? {
+          driverId: data.get('driverId'),
+          type: data.get('type'),
+          description: data.get('description') || undefined,
+          occurredAt: data.get('occurredAt') || undefined,
+        }
+      : data,
+  )
+
+  const user = await requirePermission('org:admin:manage_users_and_roles')
+
+  await db.insert(driverViolations).values({
+    orgId: user.orgId,
+    driverId: values.driverId,
+    type: values.type,
+    description: values.description,
+    occurredAt: values.occurredAt ? new Date(values.occurredAt) : new Date(),
+  })
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.DRIVER_UPDATE,
+    resource: AUDIT_RESOURCES.DRIVER,
+    resourceId: values.driverId.toString(),
+    details: { violation: values.type },
+  })
+
+  revalidatePath(`/drivers/${values.driverId}`)
+  return { success: true }
+}
+
+// Add a driver certification (e.g., DOT medical)
+export const certificationSchema = z.object({
+  driverId: z.coerce.number(),
+  type: z.string().min(1),
+  issuedAt: z.string().optional(),
+  expiresAt: z.string().optional(),
+})
+export type AddCertificationInput = z.infer<typeof certificationSchema>
+
+export async function addDriverCertification(
+  data: FormData | AddCertificationInput,
+) {
+  const values = certificationSchema.parse(
+    data instanceof FormData
+      ? {
+          driverId: data.get('driverId'),
+          type: data.get('type'),
+          issuedAt: data.get('issuedAt') || undefined,
+          expiresAt: data.get('expiresAt') || undefined,
+        }
+      : data,
+  )
+
+  const user = await requirePermission('org:admin:manage_users_and_roles')
+
+  await db.insert(driverCertifications).values({
+    orgId: user.orgId,
+    driverId: values.driverId,
+    type: values.type,
+    issuedAt: values.issuedAt ? new Date(values.issuedAt) : null,
+    expiresAt: values.expiresAt ? new Date(values.expiresAt) : null,
+  })
+
+  await createAuditLog({
+    action: AUDIT_ACTIONS.DRIVER_UPDATE,
+    resource: AUDIT_RESOURCES.DRIVER,
+    resourceId: values.driverId.toString(),
+    details: { certification: values.type },
+  })
+
+  revalidatePath(`/drivers/${values.driverId}`)
   return { success: true }
 }

--- a/main/src/lib/actions/loads.ts
+++ b/main/src/lib/actions/loads.ts
@@ -161,7 +161,7 @@ export async function bulkExportLoads(ids: number[]) {
   await requirePermission('org:dispatcher:create_edit_loads');
   try {
     exportSchema.parse({ ids })
-  } catch (err) {
+  } catch {
     return new Response('Invalid request', { status: 400 })
   }
   const rows = await db.select().from(loads).where(inArray(loads.id, ids));

--- a/main/src/lib/schema.ts
+++ b/main/src/lib/schema.ts
@@ -118,6 +118,8 @@ export const drivers = pgTable("drivers", {
     .references(() => users.id)
     .notNull(),
   licenseNumber: varchar("license_number", { length: 50 }),
+  licenseClass: varchar("license_class", { length: 5 }),
+  endorsements: varchar("endorsements", { length: 255 }),
   licenseExpiry: timestamp("license_expiry"),
   dotNumber: varchar("dot_number", { length: 50 }),
   status: driverStatusEnum("status").default("AVAILABLE").notNull(),
@@ -442,6 +444,28 @@ export const driverTrainings = pgTable('driver_trainings', {
   createdAt: timestamp('created_at').defaultNow().notNull(),
 });
 
+// Driver license violations
+export const driverViolations = pgTable('driver_violations', {
+  id: serial('id').primaryKey(),
+  orgId: integer('org_id').references(() => organizations.id).notNull(),
+  driverId: integer('driver_id').references(() => drivers.id).notNull(),
+  type: varchar('type', { length: 50 }).notNull(),
+  description: text('description'),
+  occurredAt: timestamp('occurred_at').defaultNow().notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
+// Driver certifications (DOT medical, hazmat, etc.)
+export const driverCertifications = pgTable('driver_certifications', {
+  id: serial('id').primaryKey(),
+  orgId: integer('org_id').references(() => organizations.id).notNull(),
+  driverId: integer('driver_id').references(() => drivers.id).notNull(),
+  type: varchar('type', { length: 50 }).notNull(),
+  issuedAt: timestamp('issued_at'),
+  expiresAt: timestamp('expires_at'),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});
+
 // Driver benefits
 export const driverBenefits = pgTable('driver_benefits', {
   id: serial('id').primaryKey(),
@@ -496,6 +520,8 @@ export const organizationsRelations = relations(organizations, ({ many }) => ({
   trainingPrograms: many(trainingPrograms),
   driverTrainings: many(driverTrainings),
   driverBenefits: many(driverBenefits),
+  driverViolations: many(driverViolations),
+  driverCertifications: many(driverCertifications),
   payStatements: many(payStatements),
   iftaAuditResponses: many(iftaAuditResponses),
 }));
@@ -546,6 +572,8 @@ export const driversRelations = relations(drivers, ({ one, many }) => ({
   accidentReports: many(accidentReports),
   trainings: many(driverTrainings),
   benefits: many(driverBenefits),
+  violations: many(driverViolations),
+  certifications: many(driverCertifications),
   payStatements: many(payStatements),
 }));
 
@@ -718,6 +746,10 @@ export type DriverTraining = typeof driverTrainings.$inferSelect;
 export type NewDriverTraining = typeof driverTrainings.$inferInsert;
 export type DriverBenefit = typeof driverBenefits.$inferSelect;
 export type NewDriverBenefit = typeof driverBenefits.$inferInsert;
+export type DriverViolation = typeof driverViolations.$inferSelect;
+export type NewDriverViolation = typeof driverViolations.$inferInsert;
+export type DriverCertification = typeof driverCertifications.$inferSelect;
+export type NewDriverCertification = typeof driverCertifications.$inferInsert;
 export type PayStatement = typeof payStatements.$inferSelect;
 export type NewPayStatement = typeof payStatements.$inferInsert;
 export type IftaAuditResponse = typeof iftaAuditResponses.$inferSelect;


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: drivers
Milestone: MVP

## Description
Adds initial license and certification tracking features for drivers. Schema now stores CDL class and endorsements along with new tables for driver violations and certifications. Server actions handle recording violations and certifications. Driver pages display these records with forms for adding entries.

## Related Issue
Closes #50 - [Drivers] Feature: Implement License and Certification Tracking (MVP)

## Wave Dependencies
- Builds on existing driver management features
- Enables future compliance tracking

## Domain Impact
- Primary domain: drivers
- Files modified in `main/src/features/drivers`, `main/src/lib`, and driver pages

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or managed
- [ ] Ready for wave progression

## Testing Performed
- `npm run lint`
- `npm run typecheck` *(failed: multiple TS errors)*
- `npm run test` *(failed: environment setup issues)*

------
https://chatgpt.com/codex/tasks/task_e_6866c6721a148327b1504f1e25ee2676