### PR TITLE
[Admin] feat: application settings management (Advanced)

### DIFF
--- a/main/src/components/ui/textarea.tsx
+++ b/main/src/components/ui/textarea.tsx
@@ -6,7 +6,7 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
     <textarea
       data-slot="textarea"
       className={cn(
-        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        'text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
         className
       )}
       {...props}

--- a/main/src/components/ui/textarea.tsx
+++ b/main/src/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input flex w-full rounded-md border bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/main/src/features/admin/README.md
+++ b/main/src/features/admin/README.md
@@ -25,3 +25,16 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 - `/dashboard/admin/tenant` – Multi-tenant administration and monitoring.
 - `/dashboard/admin` – Admin dashboard and system metrics overview.
 
+## Application & Integration Settings
+
+The admin dashboard exposes forms to manage organization-wide settings and
+integrations.
+
+- **Application Settings** – Configure feature toggles, maintenance mode, API
+  rate limits, session timeout and security policies. Data is stored in the
+  `organizations.settings.applicationSettings` JSON column and updated via the
+  `updateApplicationSettingsAction` server action.
+- **Integration Management** – Manage third-party services. Admins can update
+  API keys, webhook URLs and toggle integrations on or off. Keys can be
+  regenerated using `generateIntegrationApiKey`.
+

--- a/main/src/features/admin/components/ApplicationSettingsForm.tsx
+++ b/main/src/features/admin/components/ApplicationSettingsForm.tsx
@@ -1,0 +1,80 @@
+import { getApplicationSettings } from '@/lib/fetchers/admin'
+import { updateApplicationSettingsAction } from '@/lib/actions/admin'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Textarea } from '@/components/ui/textarea'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+interface Props { orgId: number }
+
+export default async function ApplicationSettingsForm({ orgId }: Props) {
+  const settings = await getApplicationSettings(orgId)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Application Settings</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={updateApplicationSettingsAction} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="featureToggles">Feature Toggles (JSON)</Label>
+            <Textarea
+              id="featureToggles"
+              name="featureToggles"
+              defaultValue={
+                settings?.featureToggles
+                  ? JSON.stringify(settings.featureToggles)
+                  : ''
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="maintenanceMode">Maintenance Mode</Label>
+            <select
+              id="maintenanceMode"
+              name="maintenanceMode"
+              className="border rounded-md h-9 px-3 w-full"
+              defaultValue={settings?.maintenanceMode ? 'true' : 'false'}
+            >
+              <option value="false">Off</option>
+              <option value="true">On</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="rateLimit">API Rate Limit</Label>
+            <Input
+              id="rateLimit"
+              name="rateLimit"
+              type="number"
+              defaultValue={settings?.rateLimit ?? ''}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sessionTimeout">Session Timeout (min)</Label>
+            <Input
+              id="sessionTimeout"
+              name="sessionTimeout"
+              type="number"
+              defaultValue={settings?.sessionTimeout ?? ''}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="securityPolicies">Security Policies (JSON)</Label>
+            <Textarea
+              id="securityPolicies"
+              name="securityPolicies"
+              defaultValue={
+                settings?.securityPolicies
+                  ? JSON.stringify(settings.securityPolicies)
+                  : ''
+              }
+            />
+          </div>
+          <Button type="submit">Save</Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/features/admin/components/IntegrationManagementForm.tsx
+++ b/main/src/features/admin/components/IntegrationManagementForm.tsx
@@ -1,0 +1,57 @@
+import { getIntegrationConfigs } from '@/lib/fetchers/admin'
+import { updateIntegrationConfigAction, generateIntegrationApiKey } from '@/lib/actions/admin'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Button } from '@/components/ui/button'
+
+interface Props { orgId: number; service: string }
+
+export default async function IntegrationManagementForm({ orgId, service }: Props) {
+  const configs = await getIntegrationConfigs(orgId)
+  const cfg = configs.find(c => c.service === service)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{service} Integration</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={updateIntegrationConfigAction} className="space-y-4">
+          <input type="hidden" name="service" value={service} />
+          <div className="space-y-2">
+            <Label htmlFor="apiKey">API Key</Label>
+            <Input id="apiKey" name="apiKey" defaultValue={cfg?.apiKey ?? ''} />
+            <Button
+              formAction={async () => {
+                'use server'
+                await generateIntegrationApiKey(service)
+              }}
+              type="button"
+              className="mt-2"
+            >
+              Generate New Key
+            </Button>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="webhookUrl">Webhook URL</Label>
+            <Input id="webhookUrl" name="webhookUrl" defaultValue={cfg?.webhookUrl ?? ''} />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="enabled">Enabled</Label>
+            <select
+              id="enabled"
+              name="enabled"
+              className="border rounded-md h-9 px-3 w-full"
+              defaultValue={cfg?.enabled ? 'true' : 'false'}
+            >
+              <option value="false">Disabled</option>
+              <option value="true">Enabled</option>
+            </select>
+          </div>
+          <Button type="submit">Save</Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/main/src/features/admin/types.ts
+++ b/main/src/features/admin/types.ts
@@ -19,3 +19,24 @@ export interface TenantMetrics {
   subscriptionPlan: string;
   crossOrgLoadAssignments: number;
 }
+
+export interface ApplicationSettings {
+  featureToggles?: Record<string, boolean>;
+  maintenanceMode?: boolean;
+  rateLimit?: number;
+  sessionTimeout?: number;
+  securityPolicies?: Record<string, unknown>;
+}
+
+export interface IntegrationConfig {
+  service: string;
+  apiKey?: string;
+  webhookUrl?: string;
+  enabled: boolean;
+}
+
+export interface IntegrationStatus {
+  service: string;
+  status: 'ok' | 'error' | 'disabled';
+  lastChecked: Date;
+}

--- a/main/src/lib/fetchers/admin.ts
+++ b/main/src/lib/fetchers/admin.ts
@@ -158,7 +158,7 @@ export async function getIntegrationConfigs(
     .where(eq(organizations.id, orgId));
 
   const settings = org?.settings as Record<string, unknown> | undefined;
-  return (settings?.integrationConfigs as IntegrationConfig[]) ?? [];
+  return Object.values(settings?.integrationConfigs || {}) as IntegrationConfig[];
 }
 
 export async function getIntegrationStatuses(

--- a/main/src/lib/fetchers/admin.ts
+++ b/main/src/lib/fetchers/admin.ts
@@ -5,6 +5,9 @@ import type {
   TenantConfig,
   ResourceAllocation,
   TenantMetrics,
+  ApplicationSettings,
+  IntegrationConfig,
+  IntegrationStatus,
 } from "@/features/admin/types";
 
 export async function checkTenantIsolation(orgId: number) {
@@ -132,4 +135,40 @@ export async function fetchRecentAuditLogs(
     LIMIT ${limit}
   `);
   return res.rows;
+}
+
+export async function getApplicationSettings(
+  orgId: number,
+): Promise<ApplicationSettings | null> {
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId));
+
+  const settings = org?.settings as Record<string, unknown> | undefined;
+  return (settings?.applicationSettings as ApplicationSettings) ?? null;
+}
+
+export async function getIntegrationConfigs(
+  orgId: number,
+): Promise<IntegrationConfig[]> {
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId));
+
+  const settings = org?.settings as Record<string, unknown> | undefined;
+  return (settings?.integrationConfigs as IntegrationConfig[]) ?? [];
+}
+
+export async function getIntegrationStatuses(
+  orgId: number,
+): Promise<IntegrationStatus[]> {
+  const [org] = await db
+    .select({ settings: organizations.settings })
+    .from(organizations)
+    .where(eq(organizations.id, orgId));
+
+  const settings = org?.settings as Record<string, unknown> | undefined;
+  return (settings?.integrationStatuses as IntegrationStatus[]) ?? [];
 }

--- a/main/tests/admin/app-integrations.test.ts
+++ b/main/tests/admin/app-integrations.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  updateApplicationSettingsAction,
+  updateIntegrationConfigAction,
+  generateIntegrationApiKey,
+} from '@/lib/actions/admin'
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([{ settings: {} }])) })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => ({ returning: vi.fn() })) })) })),
+  },
+}))
+vi.mock('@/lib/rbac', () => ({ requireRole: vi.fn(async () => ({ id: '1', orgId: 1 })) }))
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { ORG_SETTINGS_UPDATE: 'org.update' },
+  AUDIT_RESOURCES: { ORGANIZATION: 'org' },
+}))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/utils', () => ({ generateSecureToken: () => 'newkey' }))
+
+const mockedDb = require('@/lib/db').db
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('updateApplicationSettingsAction', () => {
+  it('updates settings', async () => {
+    const form = new FormData()
+    form.set('maintenanceMode', 'true')
+    form.set('featureToggles', JSON.stringify({ a: true }))
+    const res = await updateApplicationSettingsAction(form)
+    expect(res.success).toBe(true)
+    expect(mockedDb.update).toHaveBeenCalled()
+  })
+})
+
+describe('updateIntegrationConfigAction', () => {
+  it('updates integration config', async () => {
+    const form = new FormData()
+    form.set('service', 'maps')
+    form.set('apiKey', 'abc')
+    form.set('enabled', 'true')
+    const res = await updateIntegrationConfigAction(form)
+    expect(res.success).toBe(true)
+    expect(mockedDb.update).toHaveBeenCalled()
+  })
+})
+
+describe('generateIntegrationApiKey', () => {
+  it('generates and stores key', async () => {
+    const res = await generateIntegrationApiKey('maps')
+    expect(res.apiKey).toBe('newkey')
+    expect(mockedDb.update).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Wave & Domain Context
Wave: 8
Domain: admin
Milestone: Advanced

## Description
Adds server actions, fetchers and UI components to manage application settings and third‑party integrations from the admin dashboard. Admins can configure feature toggles, maintenance mode, rate limiting and integration API keys with regeneration support.

## Related Issue
Closes #23 - [Admin] Feature: Implement Application and Integration Settings (Advanced)

## Wave Dependencies
- Builds on: existing admin forms and settings actions
- Enables: future monitoring tasks
- Cross-domain integration: none

## Domain Impact
- Primary domain: admin
- Files modified: main/src/features/admin, main/src/lib/actions/admin.ts, main/src/lib/fetchers/admin.ts
- Integration points: settings stored in organizations.settings JSON

## Milestone Compliance
- [x] Meets Advanced complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails with TS errors)*
- `npm run test` *(fails: vitest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866fc429f8c8327b7c8fb9b144b1c87