### PR TITLE
[IFTA] feat: expose API routes for module (Core)

### DIFF
--- a/main/src/app/api/ifta/compliance/route.ts
+++ b/main/src/app/api/ifta/compliance/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requirePermission } from '@/lib/rbac'
+import { listIftaAuditResponses } from '@/lib/fetchers/ifta'
+import { recordIftaAuditResponseAction } from '@/lib/actions/ifta'
+
+export async function GET() {
+  try {
+    const user = await requirePermission('org:compliance:access_audit_logs')
+    const responses = await listIftaAuditResponses(user.orgId)
+    return NextResponse.json({ success: true, responses })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requirePermission('org:compliance:access_audit_logs')
+    const formData = await request.formData()
+    const result = await recordIftaAuditResponseAction(formData)
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/main/src/app/api/ifta/fuel/route.ts
+++ b/main/src/app/api/ifta/fuel/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requirePermission } from '@/lib/rbac'
+import { getFuelPurchasesByOrg } from '@/lib/fetchers/ifta'
+import { createFuelPurchaseAction } from '@/lib/actions/ifta'
+
+export async function GET() {
+  try {
+    const user = await requirePermission('org:driver:log_fuel_purchase')
+    const purchases = await getFuelPurchasesByOrg(user.orgId)
+    return NextResponse.json({ success: true, purchases })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requirePermission('org:driver:log_fuel_purchase')
+    const formData = await request.formData()
+    const result = await createFuelPurchaseAction(formData)
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/main/src/app/api/ifta/import/route.ts
+++ b/main/src/app/api/ifta/import/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requirePermission } from '@/lib/rbac'
+import { importEldCsvAction, importFuelCardCsvAction } from '@/lib/actions/ifta'
+
+export async function POST(request: NextRequest) {
+  try {
+    await requirePermission('org:ifta:import_data')
+    const type = request.nextUrl.searchParams.get('type') || 'eld'
+    const formData = await request.formData()
+    if (type === 'fuelCard') {
+      await importFuelCardCsvAction(formData)
+    } else {
+      await importEldCsvAction(formData)
+    }
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/main/src/app/api/ifta/reports/route.ts
+++ b/main/src/app/api/ifta/reports/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requirePermission } from '@/lib/rbac'
+import { listIftaReports } from '@/lib/fetchers/ifta'
+import { generateIftaReportAction } from '@/lib/actions/ifta'
+
+export async function GET() {
+  try {
+    const user = await requirePermission('org:ifta:generate_report')
+    const reports = await listIftaReports(user.orgId)
+    return NextResponse.json({ success: true, reports })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requirePermission('org:ifta:generate_report')
+    const formData = await request.formData()
+    const result = await generateIftaReportAction(formData)
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/main/src/app/api/ifta/taxes/route.ts
+++ b/main/src/app/api/ifta/taxes/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requirePermission } from '@/lib/rbac'
+import { getTaxRatesByQuarter } from '@/lib/fetchers/ifta'
+import { calculateTaxAction } from '@/lib/actions/ifta'
+
+export async function GET(request: NextRequest) {
+  try {
+    const user = await requirePermission('org:ifta:generate_report')
+    const quarter = request.nextUrl.searchParams.get('quarter') || ''
+    const rates = await getTaxRatesByQuarter(quarter)
+    return NextResponse.json({ success: true, rates })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requirePermission('org:ifta:generate_report')
+    const formData = await request.formData()
+    const result = await calculateTaxAction(formData)
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/main/src/app/api/ifta/trips/route.ts
+++ b/main/src/app/api/ifta/trips/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { requirePermission } from '@/lib/rbac'
+import { getTripsByOrg } from '@/lib/fetchers/ifta'
+import { recordTripAction } from '@/lib/actions/ifta'
+
+export async function GET() {
+  try {
+    const user = await requirePermission('org:driver:record_trip')
+    const trips = await getTripsByOrg(user.orgId)
+    return NextResponse.json({ success: true, trips })
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await requirePermission('org:driver:record_trip')
+    const formData = await request.formData()
+    const result = await recordTripAction(formData)
+    return NextResponse.json(result)
+  } catch (error) {
+    return NextResponse.json(
+      { success: false, message: 'Failed', error: error instanceof Error ? error.message : 'unknown' },
+      { status: 500 },
+    )
+  }
+}

--- a/main/src/features/ifta/README.md
+++ b/main/src/features/ifta/README.md
@@ -44,3 +44,19 @@ Use the fetchers in `lib/fetchers/ifta.ts` to retrieve documents and audit respo
 - `ReceiptProcessor` uploads receipts for OCR processing.
 - `TaxCalculator` estimates tax due without creating a report.
 - `ComplianceTracker` lists auditor questions and responses.
+
+## API Endpoints
+
+The IFTA module exposes a small public API for integration purposes. Each route requires Clerk authentication and the appropriate permission.
+
+- `GET /api/ifta/trips` – List recorded trips for the authenticated organization.
+- `POST /api/ifta/trips` – Record a new trip.
+- `GET /api/ifta/fuel` – Retrieve fuel purchases.
+- `POST /api/ifta/fuel` – Log a fuel purchase.
+- `GET /api/ifta/reports` – List generated IFTA reports.
+- `POST /api/ifta/reports` – Generate a new IFTA report.
+- `GET /api/ifta/taxes` – Fetch tax rates for a quarter (`?quarter=2024Q1`).
+- `POST /api/ifta/taxes` – Calculate estimated tax due.
+- `POST /api/ifta/import?type=eld|fuelCard` – Import ELD or fuel card CSV data.
+- `GET /api/ifta/compliance` – List audit responses.
+- `POST /api/ifta/compliance` – Record an audit response.

--- a/main/src/lib/fetchers/ifta.ts
+++ b/main/src/lib/fetchers/ifta.ts
@@ -1,5 +1,5 @@
 import { db } from "@/lib/db";
-import { trips, fuelPurchases, iftaTaxRates, documents, iftaAuditResponses } from "@/lib/schema";
+import { trips, fuelPurchases, iftaTaxRates, iftaReports, documents, iftaAuditResponses } from "@/lib/schema";
 import { eq, between, and, sql } from "drizzle-orm";
 
 export async function getTripsByOrg(orgId: number) {
@@ -61,6 +61,13 @@ export async function listIftaAuditResponses(orgId: number) {
     .select()
     .from(iftaAuditResponses)
     .where(eq(iftaAuditResponses.orgId, orgId));
+}
+
+export async function listIftaReports(orgId: number) {
+  return await db
+    .select()
+    .from(iftaReports)
+    .where(eq(iftaReports.orgId, orgId));
 }
 export interface FuelEfficiency {
   totalMiles: number

--- a/main/tests/ifta-list-reports.test.ts
+++ b/main/tests/ifta-list-reports.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { listIftaReports } from '../src/lib/fetchers/ifta'
 import { db } from '../src/lib/db'
 
-vi.mock('../src/lib/db', () => ({
+vi.mock('@/lib/db', () => ({
   db: { select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn() })) })) }
 }))
 

--- a/main/tests/ifta-list-reports.test.ts
+++ b/main/tests/ifta-list-reports.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect, vi } from 'vitest'
+import { listIftaReports } from '../src/lib/fetchers/ifta'
+import { db } from '../src/lib/db'
+
+vi.mock('../src/lib/db', () => ({
+  db: { select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn() })) })) }
+}))
+
+describe('listIftaReports', () => {
+  it('queries by orgId', async () => {
+    const where = vi.fn()
+    vi.mocked(db.select).mockReturnValueOnce({ from: vi.fn(() => ({ where })) } as any)
+    await listIftaReports(1)
+    expect(where).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: ifta
Milestone: Core

## Description
Adds public API routes for the IFTA module along with a new fetcher for listing IFTA reports. Documentation has been updated to describe the new endpoints.

## Related Issue
Closes #64 - [IFTA] Feature: Implement API Endpoints and Data Management (Core)

## Wave Dependencies
- Builds on existing IFTA actions and fetchers
- Enables external integrations via `/api/ifta/*` routes

## Domain Impact
- Primary domain: ifta
- Files modified: `main/src/app/api/ifta/*`, `lib/fetchers/ifta.ts`, `features/ifta/README.md`, test file

## Milestone Compliance
- [x] Meets Core complexity requirements
- [x] Aligns with milestone delivery goals

## Wave Completion
- [x] Domain task completed for current wave

## Testing Performed
- `npm run lint` *(failed: next not found)*
- `npm run typecheck` *(failed: TypeScript errors due to merge markers)*
- `npm run test` *(failed: vitest not found)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_6866fb88dbd08327b07b4489eb4f3200