### PR TITLE
[Vehicles] docs: add security and tests (Advanced) (Closes #80)

### DIFF
--- a/main/src/features/vehicles/README.md
+++ b/main/src/features/vehicles/README.md
@@ -24,3 +24,16 @@ Vehicle fetchers use `unstable_cache` with `vehicles` tags to cache lists and me
 ## Mobile Features
 
 `MobileMaintenanceForm` and `MobileInspectionForm` allow technicians to record maintenance and inspections from mobile devices. Submissions are queued in `localStorage` when offline and automatically sent when connectivity returns.
+
+## Security Hardening
+
+- All server actions require RBAC permissions via `requirePermission`.
+- Inputs are validated with Zod schemas before database writes.
+- Telematics data uses `safeParseJSON` to safely parse JSON payloads.
+- Audit logs capture vehicle changes for compliance.
+
+## Testing
+
+- Unit tests cover fetchers, actions and React components under `main/tests/vehicles`.
+- Additional schema tests ensure validation rules.
+- Run `npm run test` from the `main` directory to execute the suite.

--- a/main/src/lib/actions/__tests__/vehicles.test.ts
+++ b/main/src/lib/actions/__tests__/vehicles.test.ts
@@ -1,5 +1,32 @@
-import { describe, it, expect } from 'vitest'
-import { vehicleInputSchema, maintenanceRecordSchema } from '../vehicles'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  vehicleInputSchema,
+  maintenanceRecordSchema,
+  createVehicle,
+  recordVehicleMaintenance,
+  recordVehicleTelematics,
+} from '../vehicles'
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: () => ({ values: () => ({ returning: () => Promise.resolve([{ id: 1 }]) }) }),
+  },
+}))
+
+vi.mock('@/lib/rbac', () => ({ requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })) }))
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: {
+    VEHICLE_CREATE: 'vehicle.create',
+    VEHICLE_MAINTENANCE: 'vehicle.maintenance',
+    VEHICLE_TELEMATICS: 'vehicle.telematics',
+  },
+  AUDIT_RESOURCES: { VEHICLE: 'vehicle' },
+}))
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn(), revalidateTag: vi.fn() }))
+vi.mock('@/lib/fetchers/vehicles', () => ({ VEHICLE_CACHE_TAG: 'vehicles' }))
 
 describe('vehicleInputSchema', () => {
   it('accepts valid data', () => {
@@ -33,5 +60,39 @@ describe('maintenanceRecordSchema', () => {
 
   it('rejects invalid date', () => {
     expect(() => maintenanceRecordSchema.parse({ maintenanceDate: '' })).toThrow()
+  })
+})
+
+describe('createVehicle', () => {
+  beforeEach(() => vi.clearAllMocks())
+  it('inserts vehicle with valid data', async () => {
+    const data = {
+      vin: '1',
+      licensePlate: 'A',
+      make: 'Ford',
+      model: 'F150',
+      year: 2020,
+    }
+    const result = await createVehicle(data)
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('recordVehicleMaintenance', () => {
+  beforeEach(() => vi.clearAllMocks())
+  it('creates maintenance record', async () => {
+    const res = await recordVehicleMaintenance(1, { maintenanceDate: new Date() })
+    expect(res.success).toBe(true)
+  })
+})
+
+describe('recordVehicleTelematics', () => {
+  beforeEach(() => vi.clearAllMocks())
+  it('handles invalid json', async () => {
+    const form = new FormData()
+    form.set('vehicleId', '1')
+    form.set('data', '{bad}')
+    const result = await recordVehicleTelematics(form)
+    expect(result.success).toBe(true)
   })
 })

--- a/main/src/lib/actions/vehicles.ts
+++ b/main/src/lib/actions/vehicles.ts
@@ -8,6 +8,7 @@ import { revalidatePath, revalidateTag } from 'next/cache'
 import { VEHICLE_CACHE_TAG } from '@/lib/fetchers/vehicles'
 import { eq, inArray } from 'drizzle-orm'
 import { z } from 'zod'
+import { safeParseJSON } from '@/lib/utils'
 
 
 // Allowed vehicle types as per your DB schema
@@ -181,7 +182,7 @@ export async function recordVehicleTelematics(formData: FormData) {
         input.lat && input.lng ? { lat: input.lat, lng: input.lng } : null,
       odometer: input.odometer,
       engineHours: input.engineHours,
-      data: input.data ? JSON.parse(input.data) : null,
+      data: safeParseJSON(input.data),
       createdAt: new Date(),
     })
     .returning();

--- a/main/src/lib/utils.ts
+++ b/main/src/lib/utils.ts
@@ -9,3 +9,12 @@ export function cn(...inputs: ClassValue[]) {
 export function generateSecureToken(size = 32): string {
   return randomBytes(size).toString('hex')
 }
+
+export function safeParseJSON<T>(value: string | null | undefined): T | null {
+  if (!value) return null
+  try {
+    return JSON.parse(value) as T
+  } catch {
+    return null
+  }
+}

--- a/main/tests/utils.test.ts
+++ b/main/tests/utils.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect } from 'vitest'
-import { generateSecureToken } from '../src/lib/utils'
+import { generateSecureToken, safeParseJSON } from '../src/lib/utils'
 
 describe('generateSecureToken', () => {
   it('generates tokens of expected length', () => {
     const token = generateSecureToken(16)
     expect(token).toHaveLength(32)
+  })
+})
+
+describe('safeParseJSON', () => {
+  it('returns parsed object', () => {
+    const res = safeParseJSON<{ a: number }>("{\"a\":1}")
+    expect(res?.a).toBe(1)
+  })
+
+  it('returns null on invalid input', () => {
+    const res = safeParseJSON('{bad}')
+    expect(res).toBeNull()
   })
 })

--- a/main/tests/vehicles/fetchers.test.ts
+++ b/main/tests/vehicles/fetchers.test.ts
@@ -26,3 +26,28 @@ describe('getVehicleList', () => {
     expect(where).toHaveBeenCalled()
   })
 })
+
+describe('getVehicleById', () => {
+  it('calls where', async () => {
+    const where = vi.fn(() => Promise.resolve([{ id: 1 }]))
+    vi.mocked(db.select).mockReturnValueOnce({ from: vi.fn(() => ({ where })) } as any)
+    await fetchers.getVehicleById(1)
+    expect(where).toHaveBeenCalled()
+  })
+})
+
+describe('listVehicleMaintenance', () => {
+  it('maps rows', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 1, vehicleId: 1, maintenanceDate: new Date(), mileage: 10, vendor: 'A', description: null, cost: 5 }] } as any)
+    const res = await fetchers.listVehicleMaintenance(1)
+    expect(res[0].id).toBe(1)
+  })
+})
+
+describe('getMaintenanceAlerts', () => {
+  it('returns alerts', async () => {
+    vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ id: 1, next_maintenance_date: new Date() }] } as any)
+    const res = await fetchers.getMaintenanceAlerts(1)
+    expect(res).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Wave & Domain Context
Wave: 3
Domain: vehicles
Milestone: Advanced

## Description
Adds new security helper and documentation for the Vehicles module along with unit tests that cover actions and fetchers. `safeParseJSON` prevents crashes from malformed telematics data and README now outlines security hardening and testing instructions.

## Related Issue
Closes #80 - [Vehicles] Documentation: Implement Testing, Security, and Documentation (Advanced)

## Wave Dependencies
- Builds on existing vehicle actions and fetchers.
- Enables further security focused work in later waves.

## Domain Impact
- Primary domain: vehicles
- Files modified: `main/src/lib/actions/vehicles.ts`, `main/src/lib/utils.ts`, tests under `main/tests/vehicles/`, docs `main/src/features/vehicles/README.md`
- Integration points: none

## Milestone Compliance
- [x] Meets Advanced complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [x] Dependencies resolved or properly managed
- [x] Ready for wave progression

## Testing Performed
- `npm run lint` *(fails: project has existing lint errors)*
- `npm run typecheck` *(fails: project has existing type errors)*
- `npm run test` *(fails: several unrelated suites fail)*


------
https://chatgpt.com/codex/tasks/task_e_6866fb6451b8832788f350425ece5167