### PR TITLE
[Settings] docs: add tests and rate limit (Advanced) (Closes #72)

### DIFF
--- a/main/src/app/api/settings/backup/route.ts
+++ b/main/src/app/api/settings/backup/route.ts
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server';
 import { backupOrganizationSettings } from '@/lib/actions/settings';
 import { requirePermission } from '@/lib/rbac';
+import { checkRateLimit } from '@/lib/rateLimit';
 
 export async function POST() {
   try {
+    if (!checkRateLimit('settings-backup-post')) {
+      return NextResponse.json({ success: false, message: 'Rate limit exceeded' }, { status: 429 });
+    }
     await requirePermission('org:admin:configure_company_settings');
     const file = await backupOrganizationSettings();
     return NextResponse.json({ success: true, file });

--- a/main/src/app/api/settings/mobile/route.ts
+++ b/main/src/app/api/settings/mobile/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { updateMobileSettingsAction } from '@/lib/actions/settings';
 import { getMobileSettings } from '@/lib/fetchers/settings';
 import { requirePermission } from '@/lib/rbac';
+import { checkRateLimit } from '@/lib/rateLimit';
 import { z } from 'zod';
 
 const bodySchema = z.object({
@@ -14,6 +15,9 @@ const bodySchema = z.object({
 
 export async function GET() {
   try {
+    if (!checkRateLimit('settings-mobile-get')) {
+      return NextResponse.json({ success: false, message: 'Rate limit exceeded' }, { status: 429 });
+    }
     await requirePermission('org:admin:configure_company_settings');
     const settings = await getMobileSettings();
     return NextResponse.json({ success: true, settings });
@@ -27,6 +31,9 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    if (!checkRateLimit('settings-mobile-post')) {
+      return NextResponse.json({ success: false, message: 'Rate limit exceeded' }, { status: 429 });
+    }
     await requirePermission('org:admin:configure_company_settings');
     const data = bodySchema.parse(await request.json());
     await updateMobileSettingsAction(data);

--- a/main/src/app/api/settings/workflow/route.ts
+++ b/main/src/app/api/settings/workflow/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { updateWorkflowAutomationSettingsAction } from '@/lib/actions/settings';
 import { getWorkflowAutomationSettings } from '@/lib/fetchers/settings';
 import { requirePermission } from '@/lib/rbac';
+import { checkRateLimit } from '@/lib/rateLimit';
 import { z } from 'zod';
 
 const bodySchema = z.object({
@@ -11,6 +12,9 @@ const bodySchema = z.object({
 
 export async function GET() {
   try {
+    if (!checkRateLimit('settings-workflow-get')) {
+      return NextResponse.json({ success: false, message: 'Rate limit exceeded' }, { status: 429 });
+    }
     await requirePermission('org:admin:configure_company_settings');
     const settings = await getWorkflowAutomationSettings();
     return NextResponse.json({ success: true, settings });
@@ -24,6 +28,9 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    if (!checkRateLimit('settings-workflow-post')) {
+      return NextResponse.json({ success: false, message: 'Rate limit exceeded' }, { status: 429 });
+    }
     await requirePermission('org:admin:configure_company_settings');
     const data = bodySchema.parse(await request.json());
     await updateWorkflowAutomationSettingsAction(data);

--- a/main/tests/settings/analyticsSettings.test.ts
+++ b/main/tests/settings/analyticsSettings.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateAnalyticsSettingsAction } from '@/lib/actions/settings';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([{ settings: {} }])) })) })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+  },
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { ORG_SETTINGS_UPDATE: 'org.settings.update' },
+  AUDIT_RESOURCES: { ORGANIZATION: 'organization' },
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+describe('updateAnalyticsSettingsAction', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('updates analytics settings', async () => {
+    const data = new FormData();
+    data.set('usageTracking', 'true');
+    data.set('optimizationInsights', 'true');
+    data.set('performanceMonitoring', 'true');
+    data.set('errorTracking', 'true');
+    const result = await updateAnalyticsSettingsAction(data);
+    expect(result).toBeUndefined();
+  });
+});

--- a/main/tests/settings/mobileSettings.test.ts
+++ b/main/tests/settings/mobileSettings.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateMobileSettingsAction } from '@/lib/actions/settings';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([{ settings: {} }])) })) })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+  },
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { ORG_SETTINGS_UPDATE: 'org.settings.update' },
+  AUDIT_RESOURCES: { ORGANIZATION: 'organization' },
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+describe('updateMobileSettingsAction', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('updates mobile settings', async () => {
+    const data = new FormData();
+    data.set('offlineMode', 'true');
+    data.set('pushNotifications', 'true');
+    data.set('gpsTracking', 'true');
+    data.set('batterySaver', 'true');
+    data.set('dataSaver', 'true');
+    const result = await updateMobileSettingsAction(data);
+    expect(result).toBeUndefined();
+  });
+});

--- a/main/tests/settings/workflowAutomation.test.ts
+++ b/main/tests/settings/workflowAutomation.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { updateWorkflowAutomationSettingsAction } from '@/lib/actions/settings';
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn(() => ({ from: vi.fn(() => ({ where: vi.fn(() => Promise.resolve([{ settings: {} }])) })) })),
+    update: vi.fn(() => ({ set: vi.fn(() => ({ where: vi.fn(() => Promise.resolve()) })) })),
+  },
+}));
+
+vi.mock('@/lib/rbac', () => ({
+  requirePermission: vi.fn(async () => ({ id: '1', orgId: 1 })),
+}));
+
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { ORG_SETTINGS_UPDATE: 'org.settings.update' },
+  AUDIT_RESOURCES: { ORGANIZATION: 'organization' },
+}));
+
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }));
+
+describe('updateWorkflowAutomationSettingsAction', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  it('updates workflow automation settings', async () => {
+    const data = new FormData();
+    data.set('enabled', 'true');
+    data.set('approvalsRequired', 'true');
+    const result = await updateWorkflowAutomationSettingsAction(data);
+    expect(result).toBeUndefined();
+  });
+});

--- a/wiki/Settings-Guide.md
+++ b/wiki/Settings-Guide.md
@@ -19,3 +19,11 @@ This guide summarizes key configuration areas within the Settings module.
 ## Analytics & Monitoring
 - Control usage tracking and optimization insights.
 - Enable performance monitoring and error tracking.
+
+## API Endpoints
+- `/api/settings/workflow` – manage workflow automation settings (rate limited)
+- `/api/settings/security` – update security preferences (rate limited)
+- `/api/settings/mobile` – configure mobile options (rate limited)
+- `/api/settings/backup` – download organization settings backup (rate limited)
+
+All endpoints validate input with Zod and require `org:admin:configure_company_settings` permission.


### PR DESCRIPTION
## Wave & Domain Context
Wave: 3
Domain: settings
Milestone: Advanced

## Description
Adds unit tests for advanced settings actions and introduces rate limiting to several settings API routes. Documentation is updated with endpoint information.

## Related Issue
Closes #72 - [Settings] Documentation: Implement Testing, Security, and Documentation for Settings Module (Advanced)

## Wave Dependencies
- Builds on: existing settings module implementation
- Enables: future waves needing secure endpoints
- Cross-domain integration: none

## Domain Impact
- Primary domain: settings
- Files modified: `main/src/app/api/settings/*`, `main/tests/settings/*`, `wiki/Settings-Guide.md`
- Integration points: API routes for settings

## Milestone Compliance
- [ ] Meets Advanced complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_686702419b008327a4a597c5201cd101