### PR TITLE
[IFTA] fix: Remove conflict marker in fetcher (Core) (Closes #38)

### DIFF
--- a/main/src/lib/fetchers/ifta.ts
+++ b/main/src/lib/fetchers/ifta.ts
@@ -122,7 +122,7 @@ export async function fetchTaxEfficientStates(orgId: number): Promise<TaxRateSug
     LIMIT 3
   `)
   return rates.rows.map(r => ({ state: r.state, rate: r.rate }))
-=======
+}
 
 export interface IftaOverview {
   totalTrips: number;


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: ifta
Milestone: Core

## Description
Cleaned up a leftover merge conflict marker in the IFTA fetcher and added the missing closing brace so the file compiles.

## Related Issue
Closes #38 - IFTA fix: cleanup merge artifact (Core)

## Wave Dependencies
- Builds on: none
- Enables: future IFTA development
- Cross-domain integration: none

## Domain Impact
- Primary domain: ifta
- Files modified: `main/src/lib/fetchers/ifta.ts`
- Integration points: none

## Milestone Compliance
- [ ] Meets Core complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_68670b0cc8e8832796e628790e9ba135