### PR TITLE
[Analytics] test: Fix accident rate expectation (MVP) (Closes #38)

### DIFF
--- a/main/tests/analytics/safety.fetchers.test.ts
+++ b/main/tests/analytics/safety.fetchers.test.ts
@@ -10,7 +10,8 @@ describe('fetchAccidentRate', () => {
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ sum: 1000 }] } as any)
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
     const res = await fetchAccidentRate(1)
-    expect(res.accidentsPerMillionMiles).toBeCloseTo(2000, 2)
+    const expected = 2 / (1000 / 1e6)
+    expect(res.accidentsPerMillionMiles).toBeCloseTo(expected, 2)
   })
 })
 

--- a/main/tests/analytics/safety.fetchers.test.ts
+++ b/main/tests/analytics/safety.fetchers.test.ts
@@ -10,7 +10,7 @@ describe('fetchAccidentRate', () => {
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ sum: 1000 }] } as any)
     vi.mocked(db.execute).mockResolvedValueOnce({ rows: [{ count: 2 }] } as any)
     const res = await fetchAccidentRate(1)
-    expect(res.accidentsPerMillionMiles).toBeCloseTo(2000000, 2)
+    expect(res.accidentsPerMillionMiles).toBeCloseTo(2000, 2)
   })
 })
 


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: analytics
Milestone: MVP

## Description
Corrected the expected value for accidents per million miles in the safety fetcher tests to match the calculation logic.

## Related Issue
Closes #38 - Analytics test: Accident rate expectation incorrect (MVP)

## Wave Dependencies
- Builds on: none
- Enables: future analytics test adjustments
- Cross-domain integration: none

## Domain Impact
- Primary domain: analytics
- Files modified: main/tests/analytics/safety.fetchers.test.ts
- Integration points: none

## Milestone Compliance
- [ ] Meets MVP complexity requirements
- [ ] Aligns with milestone delivery goals
- [ ] No scope creep beyond milestone definition

## Wave Completion
- [ ] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met



------
https://chatgpt.com/codex/tasks/task_e_68670b10c5dc832787f110bb760dcfc1