### PR TITLE
[Admin] test: Add invite email test (MVP) (Closes #38)

### DIFF
--- a/main/tests/admin/inviteUserAction.test.ts
+++ b/main/tests/admin/inviteUserAction.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { inviteUserAction } from '@/lib/actions/admin'
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(() => Promise.resolve([{ id: 1 }]))
+      }))
+    }))
+  }
+}))
+vi.mock('@/lib/rbac', () => ({ requirePermission: vi.fn(async () => ({ id: '1', orgId: 1, organizationName: 'Acme' })) }))
+vi.mock('@/lib/audit', () => ({
+  createAuditLog: vi.fn(),
+  AUDIT_ACTIONS: { USER_INVITE: 'invite' },
+  AUDIT_RESOURCES: { USER: 'user' }
+}))
+vi.mock('@/lib/email', () => ({ sendEmail: vi.fn() }))
+vi.mock('next/cache', () => ({ revalidatePath: vi.fn() }))
+vi.mock('@/lib/utils', () => ({ generateSecureToken: () => 'tok' }))
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('inviteUserAction', () => {
+  it('sends an invitation email', async () => {
+    const form = new FormData()
+    form.set('email', 'test@example.com')
+    form.set('role', 'MEMBER')
+    const res = await inviteUserAction(form)
+    expect(res.success).toBe(true)
+    const { sendEmail } = require('@/lib/email')
+    expect(sendEmail).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Wave & Domain Context
Wave: 1
Domain: admin
Milestone: MVP

## Description
Adds a unit test verifying that `inviteUserAction` triggers email sending. Mocks are used for database, RBAC, audit, and utilities.

## Related Issue
Closes #38 - Admin test: ensure invitation emails are sent (MVP)

## Wave Dependencies
- Builds on: none
- Enables: future invite flow validations
- Cross-domain integration: none

## Domain Impact
- Primary domain: admin
- Files modified: main/tests/admin/inviteUserAction.test.ts
- Integration points: server action `inviteUserAction`

## Milestone Compliance
- [x] Meets MVP complexity requirements
- [x] Aligns with milestone delivery goals
- [x] No scope creep beyond milestone definition

## Wave Completion
- [x] Domain task completed for current wave
- [ ] Dependencies resolved or properly managed
- [ ] Ready for wave progression

## Testing Performed
- [ ] Domain-specific functionality verified
- [ ] Cross-domain integrations tested
- [ ] Wave dependencies validated
- [ ] Milestone requirements met


------
https://chatgpt.com/codex/tasks/task_e_68670b11a1f08327a894764525b24c7d